### PR TITLE
Expose policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ version = "1.0"
 optional = true
 version = "1.0"
 
+[dependencies.chrono]
+optional = true
+version = "0.4.19"
+
 [dependencies.base58check]
 optional = true
 version = "0.1"
@@ -31,7 +35,7 @@ default = ["std"]
 
 std = []
 
-derive-serde = ["serde", "serde_json", "std", "base58check"]
+derive-serde = ["serde", "serde_json", "std", "base58check", "chrono"]
 
 [lib]
 # Since we don't define an allocator in this crate, we can only produce an rlib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-contracts-common"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Concordium <info@concordium.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -264,54 +264,6 @@ impl Deserial for Address {
     }
 }
 
-impl Serial for InitContext {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        self.metadata.serial(out)?;
-        self.init_origin.serial(out)
-    }
-}
-
-impl Deserial for InitContext {
-    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
-        let metadata = source.get()?;
-        let init_origin = source.get()?;
-        Ok(Self {
-            metadata,
-            init_origin,
-        })
-    }
-}
-
-impl Serial for ReceiveContext {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        self.metadata.serial(out)?;
-        self.invoker.serial(out)?;
-        self.self_address.serial(out)?;
-        self.self_balance.serial(out)?;
-        self.sender.serial(out)?;
-        self.owner.serial(out)
-    }
-}
-
-impl Deserial for ReceiveContext {
-    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
-        let metadata = source.get()?;
-        let invoker = source.get()?;
-        let self_address = source.get()?;
-        let self_balance = source.get()?;
-        let sender = source.get()?;
-        let owner = source.get()?;
-        Ok(ReceiveContext {
-            metadata,
-            invoker,
-            self_address,
-            self_balance,
-            sender,
-            owner,
-        })
-    }
-}
-
 impl Serial for ChainMetadata {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
         self.slot_number.serial(out)?;
@@ -606,13 +558,6 @@ repeat_macro!(
     32
 );
 
-impl InitContext {
-    pub fn init_origin(&self) -> &AccountAddress { &self.init_origin }
-
-    /// Get time in milliseconds at the beginning of this block.
-    pub fn get_time(&self) -> u64 { self.metadata.slot_time }
-}
-
 impl Address {
     pub fn matches_account(&self, acc: &AccountAddress) -> bool {
         if let Address::Account(ref my_acc) = self {
@@ -629,25 +574,6 @@ impl Address {
             false
         }
     }
-}
-
-impl ReceiveContext {
-    pub fn sender(&self) -> &Address { &self.sender }
-
-    /// Who invoked this transaction.
-    pub fn invoker(&self) -> &AccountAddress { &self.invoker }
-
-    /// Get time in milliseconds at the beginning of this block.
-    pub fn get_time(&self) -> u64 { self.metadata.slot_time }
-
-    /// Who is the owner of this contract.
-    pub fn owner(&self) -> &AccountAddress { &self.owner }
-
-    /// Balance on the smart contract when it was invoked.
-    pub fn self_balance(&self) -> Amount { self.self_balance }
-
-    /// Address of the smart contract.
-    pub fn self_address(&self) -> &ContractAddress { &self.self_address }
 }
 
 impl Serial for AttributeTag {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -650,40 +650,6 @@ impl ReceiveContext {
     pub fn self_address(&self) -> &ContractAddress { &self.self_address }
 }
 
-pub struct ReadAttributeIterator<'a, R> {
-    pos:    u16,
-    len:    u16,
-    source: &'a mut R,
-}
-
-impl<'a, R: Read + 'a> Policy<ReadAttributeIterator<'a, R>> {
-    // /// Get the value of the given attribute, if present.
-    // pub fn get_attribute(&self, tag: AttributeTag) -> Option<&AttributeValue> {
-    //     match self.items.binary_search_by_key(&tag, |x| x.0) {
-    //         Ok(idx) => Some(&self.items[idx].1),
-    //         Err(_) => None,
-    //     }
-    // }
-
-    pub fn deserial(source: &'a mut R) -> ParseResult<Self> {
-        let identity_provider = source.get()?;
-        let created_at = source.get()?;
-        let valid_to = source.get()?;
-        let len: u16 = source.get()?;
-        let items = ReadAttributeIterator {
-            pos: 0,
-            len,
-            source,
-        };
-        Ok(Self {
-            identity_provider,
-            created_at,
-            valid_to,
-            items,
-        })
-    }
-}
-
 impl Serial for AttributeTag {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.0.serial(out) }
 }
@@ -692,27 +658,46 @@ impl Deserial for AttributeTag {
     fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> { Ok(AttributeTag(source.get()?)) }
 }
 
-impl<'a, R: Read> ReadAttributeIterator<'a, R> {
-    /// Get the next attribute, storing it in the provided buffer.
-    /// The return value, if Some, is a pair of an attribute tag, and the length
-    /// of the attribute value.
-    ///
-    /// The reason this function is added here, and we don't simply implement
-    /// an Iterator for this type is that with the supplied buffer we can
-    /// iterate through the elements more efficiently, without any allocations,
-    /// the consumer being responsible for allocating the buffer.
-    pub fn next(&mut self, buf: &mut [u8; 31]) -> Option<(AttributeTag, u8)> {
-        if self.pos == self.len {
-            return None;
+impl Serial for OwnedPolicy {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        self.identity_provider.serial(out)?;
+        self.created_at.serial(out)?;
+        self.valid_to.serial(out)?;
+        (self.items.len() as u16).serial(out)?;
+        for item in self.items.iter() {
+            item.0.serial(out)?;
+            (item.1.len() as u8).serial(out)?;
+            out.write_all(&item.1)?;
         }
-        let tag = AttributeTag::deserial(self.source).ok()?;
-        let value_len: u8 = self.source.get().ok()?;
-        if value_len > 31 {
-            // Should not happen because all attributes fit into 31 bytes.
-            return None;
+        Ok(())
+    }
+}
+
+impl Deserial for OwnedPolicy {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        let identity_provider = source.get()?;
+        let created_at = source.get()?;
+        let valid_to = source.get()?;
+        let len: u16 = source.get()?;
+        let mut items = Vec::with_capacity(len as usize);
+        let mut buf = [0u8; 31];
+        for _ in 0..len {
+            let tag = AttributeTag::deserial(source)?;
+            let value_len: u8 = source.get()?;
+            if value_len > 31 {
+                // Should not happen because all attributes fit into 31 bytes.
+                return Err(ParseError {});
+            }
+            let value_len = usize::from(value_len);
+            source.read_exact(&mut buf[0..value_len])?;
+            items.push((tag, buf[0..value_len].to_vec()))
         }
-        self.source.read_exact(&mut buf[0..usize::from(value_len)]).ok()?;
-        Some((tag, value_len))
+        Ok(Self {
+            identity_provider,
+            created_at,
+            valid_to,
+            items,
+        })
     }
 }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -666,6 +666,7 @@ impl<'a, R: Read + 'a> Policy<ReadAttributeIterator<'a, R>> {
     // }
 
     pub fn deserial(source: &'a mut R) -> ParseResult<Self> {
+        let identity_provider = source.get()?;
         let created_at = source.get()?;
         let valid_to = source.get()?;
         let len: u16 = source.get()?;
@@ -675,6 +676,7 @@ impl<'a, R: Read + 'a> Policy<ReadAttributeIterator<'a, R>> {
             source,
         };
         Ok(Self {
+            identity_provider,
             created_at,
             valid_to,
             items,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,6 @@
 #[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
 use core::{convert, fmt, iter, ops, str};
 #[cfg(feature = "std")]
 use std::{convert, fmt, iter, ops, str};

--- a/src/types.rs
+++ b/src/types.rs
@@ -406,11 +406,15 @@ pub struct Policy<Attributes> {
     pub items: Attributes,
 }
 
+/// This implementation of deserialize is only useful when used
+/// to deserialize JSON. Other formats could be implemented in the future.
 #[cfg(feature = "derive-serde")]
-pub fn policy_deserialize<'de, D>(deserializer: D) -> Result<OwnedPolicy, D::Error>
-where
-    D: serde::Deserializer<'de>, {
-    deserializer.deserialize_map(policy_json::OwnedPolicyVisitor)
+impl<'de> SerdeDeserialize<'de> for OwnedPolicy {
+    fn deserialize<D>(deserializer: D) -> Result<OwnedPolicy, D::Error>
+    where
+        D: serde::Deserializer<'de>, {
+        deserializer.deserialize_map(policy_json::OwnedPolicyVisitor)
+    }
 }
 
 #[cfg(feature = "derive-serde")]
@@ -418,7 +422,7 @@ mod policy_json {
     use super::*;
     use convert::{TryFrom, TryInto};
 
-    pub struct OwnedPolicyVisitor;
+    pub(crate) struct OwnedPolicyVisitor;
 
     impl<'de> serde::de::Visitor<'de> for OwnedPolicyVisitor {
         type Value = OwnedPolicy;

--- a/src/types.rs
+++ b/src/types.rs
@@ -416,9 +416,15 @@ pub type OwnedAttributeValue = Vec<u8>;
 /// since the values are easier to construct.
 pub type OwnedPolicy = Policy<Vec<(AttributeTag, OwnedAttributeValue)>>;
 
+/// Index of the identity provider on the chain.
+/// An identity provider with the given index will not be replaced,
+/// so this is a stable identifier.
+pub type IdentityProvider = u32;
+
 /// Policy on the credential of the account.
 #[derive(Debug, Clone)]
 pub struct Policy<Attributes> {
+    pub identity_provider: IdentityProvider,
     /// Beginning of the month in milliseconds since unix epoch.
     pub created_at: TimestampMillis,
     /// Beginning of the month where the credential is no longer valid, in

--- a/src/types.rs
+++ b/src/types.rs
@@ -322,19 +322,6 @@ pub struct ContractAddress {
     pub subindex: u64,
 }
 
-/// Chain context accessible to the init methods.
-///
-/// TODO: We could optimize this to be initialized lazily
-#[cfg_attr(
-    feature = "derive-serde",
-    derive(SerdeSerialize, SerdeDeserialize),
-    serde(rename_all = "camelCase")
-)]
-pub struct InitContext {
-    pub metadata:    ChainMetadata,
-    pub init_origin: AccountAddress,
-}
-
 /// Either an address of an account, or contract.
 #[cfg_attr(
     feature = "derive-serde",
@@ -345,23 +332,6 @@ pub struct InitContext {
 pub enum Address {
     Account(AccountAddress),
     Contract(ContractAddress),
-}
-
-/// Chain context accessible to the receive methods.
-///
-/// TODO: We could optimize this to be initialized lazily.
-#[cfg_attr(
-    feature = "derive-serde",
-    derive(SerdeSerialize, SerdeDeserialize),
-    serde(rename_all = "camelCase")
-)]
-pub struct ReceiveContext {
-    pub metadata:     ChainMetadata,
-    pub invoker:      AccountAddress,  //32 bytes
-    pub self_address: ContractAddress, // 16 bytes
-    pub self_balance: Amount,          // 8 bytes
-    pub sender:       Address,         // 9 or 33 bytes
-    pub owner:        AccountAddress,  // 32 bytes
 }
 
 /// Sequential slot number

--- a/src/types.rs
+++ b/src/types.rs
@@ -403,18 +403,18 @@ pub type TimestampMillis = u64;
 #[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub struct AttributeTag(pub(crate) u8);
 
-pub type AttributeValue = Vec<u8>;
+pub type AttributeValue<'a> = &'a [u8];
 
 /// Policy on the credential of the account.
 #[derive(Clone)]
-pub struct Policy {
+pub struct Policy<Attributes> {
     /// Beginning of the month in milliseconds since unix epoch.
     pub created_at: TimestampMillis,
     /// Beginning of the month where the credential is no longer valid, in
     /// milliseconds since unix epoch.
     pub valid_to: TimestampMillis,
     /// List of attributes, ordered by the tag.
-    pub(crate) items: Vec<(AttributeTag, AttributeValue)>,
+    pub(crate) items: Attributes,
 }
 
 /// Currently defined attributes possible in a policy.

--- a/src/types.rs
+++ b/src/types.rs
@@ -395,6 +395,46 @@ pub struct Cursor<T> {
     pub data:   T,
 }
 
+/// Time since unix epoch in milliseconds.
+pub type TimestampMillis = u64;
+
+/// Tag of an attribute
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq)]
+pub struct AttributeTag(pub(crate) u8);
+
+pub type AttributeValue = Vec<u8>;
+
+/// Policy on the credential of the account.
+#[derive(Clone)]
+pub struct Policy {
+    /// Beginning of the month in milliseconds since unix epoch.
+    pub created_at: TimestampMillis,
+    /// Beginning of the month where the credential is no longer valid, in
+    /// milliseconds since unix epoch.
+    pub valid_to: TimestampMillis,
+    /// List of attributes, ordered by the tag.
+    pub(crate) items: Vec<(AttributeTag, AttributeValue)>,
+}
+
+/// Currently defined attributes possible in a policy.
+pub mod attributes {
+    use super::AttributeTag;
+    pub const FIRST_NAME: AttributeTag = AttributeTag(0u8);
+    pub const LAST_NAME: AttributeTag = AttributeTag(1u8);
+    pub const SEX: AttributeTag = AttributeTag(2u8);
+    pub const DOB: AttributeTag = AttributeTag(3u8);
+    pub const COUNTRY_OF_RESIDENCE: AttributeTag = AttributeTag(4u8);
+    pub const NATIONALITY: AttributeTag = AttributeTag(5u8);
+    pub const ID_DOC_TYPE: AttributeTag = AttributeTag(6u8);
+    pub const ID_DOC_NUMBER: AttributeTag = AttributeTag(7u8);
+    pub const ID_DOC_ISSUER: AttributeTag = AttributeTag(8u8);
+    pub const ID_DOC_ISSUED_AT: AttributeTag = AttributeTag(9u8);
+    pub const ID_DOC_EXPIRES_AT: AttributeTag = AttributeTag(10u8);
+    pub const NATIONAL_ID_NO: AttributeTag = AttributeTag(11u8);
+    pub const TAX_ID_NO: AttributeTag = AttributeTag(12u8);
+}
+
 /// Zero-sized type to represent an error when reading bytes and deserializing.
 ///
 /// When using custom error types in your smart contract, it is convenient to

--- a/src/types.rs
+++ b/src/types.rs
@@ -398,15 +398,26 @@ pub struct Cursor<T> {
 /// Time since unix epoch in milliseconds.
 pub type TimestampMillis = u64;
 
-/// Tag of an attribute
+/// Tag of an attribute. See the module [attributes](./attributes/index.html)
+/// for the currently supported attributes.
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq)]
-pub struct AttributeTag(pub(crate) u8);
+pub struct AttributeTag(pub u8);
 
+/// A borrowed attribute value. The slice will have at most 31 bytes.
 pub type AttributeValue<'a> = &'a [u8];
 
+/// An owned counterpart of `AttributeValue`, more convenient for testing.
+pub type OwnedAttributeValue = Vec<u8>;
+
+/// A policy with a vector of attributes, fully allocated and owned.
+/// This is in contrast to a policy which is lazily read from a read source.
+/// The latter is useful for efficiency, this type is more useful for testing
+/// since the values are easier to construct.
+pub type OwnedPolicy = Policy<Vec<(AttributeTag, OwnedAttributeValue)>>;
+
 /// Policy on the credential of the account.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Policy<Attributes> {
     /// Beginning of the month in milliseconds since unix epoch.
     pub created_at: TimestampMillis,
@@ -414,7 +425,7 @@ pub struct Policy<Attributes> {
     /// milliseconds since unix epoch.
     pub valid_to: TimestampMillis,
     /// List of attributes, ordered by the tag.
-    pub(crate) items: Attributes,
+    pub items: Attributes,
 }
 
 /// Currently defined attributes possible in a policy.


### PR DESCRIPTION
Define a notion of policy that corresponds to the information accessible about the sender.

The design of the policy is such to require a minimal overhead when accessing. This makes it slightly awkward to access, but higher-level abstractions can be built that do not require the programmer to deal with low-level, incremental policy access.

In order to simplify some of the code and dependencies this PR also
- moves Init/Receive contexts out of the library. They are only needed by the node integration, hence they are moved there.