### PR TITLE
Add transparent types for timestamp and duration

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -129,9 +129,7 @@ impl Deserial for bool {
 }
 
 impl Serial for Amount {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        out.write_u64(self.micro_gtu)
-    }
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { out.write_u64(self.micro_gtu) }
 }
 
 impl Deserial for Amount {
@@ -153,9 +151,7 @@ impl Deserial for Timestamp {
 }
 
 impl Serial for Duration {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        self.millis().serial(out)
-    }
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.millis().serial(out) }
 }
 
 impl Deserial for Duration {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -130,13 +130,37 @@ impl Deserial for bool {
 
 impl Serial for Amount {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        out.write_u64((*self).micro_gtu)
+        out.write_u64(self.micro_gtu)
     }
 }
 
 impl Deserial for Amount {
     fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
         source.read_u64().map(Amount::from_micro_gtu)
+    }
+}
+
+impl Serial for Timestamp {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        self.timestamp_millis().serial(out)
+    }
+}
+
+impl Deserial for Timestamp {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        u64::deserial(source).map(Timestamp::from_timestamp_millis)
+    }
+}
+
+impl Serial for Duration {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        self.millis().serial(out)
+    }
+}
+
+impl Deserial for Duration {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        u64::deserial(source).map(Duration::from_millis)
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -436,37 +436,39 @@ impl Deserial for Type {
             10 => Ok(Type::Amount),
             11 => Ok(Type::AccountAddress),
             12 => Ok(Type::ContractAddress),
-            13 => {
+            13 => Ok(Type::Timestamp),
+            14 => Ok(Type::Duration),
+            15 => {
                 let left = Type::deserial(source)?;
                 let right = Type::deserial(source)?;
                 Ok(Type::Pair(Box::new(left), Box::new(right)))
             }
-            14 => {
+            16 => {
                 let len_size = SizeLength::deserial(source)?;
                 let ty = Type::deserial(source)?;
                 Ok(Type::List(len_size, Box::new(ty)))
             }
-            15 => {
+            17 => {
                 let len_size = SizeLength::deserial(source)?;
                 let ty = Type::deserial(source)?;
                 Ok(Type::Set(len_size, Box::new(ty)))
             }
-            16 => {
+            18 => {
                 let len_size = SizeLength::deserial(source)?;
                 let key = Type::deserial(source)?;
                 let value = Type::deserial(source)?;
                 Ok(Type::Map(len_size, Box::new(key), Box::new(value)))
             }
-            17 => {
+            19 => {
                 let len = u32::deserial(source)?;
                 let ty = Type::deserial(source)?;
                 Ok(Type::Array(len, Box::new(ty)))
             }
-            18 => {
+            20 => {
                 let fields = source.get()?;
                 Ok(Type::Struct(fields))
             }
-            19 => {
+            21 => {
                 let variants = source.get()?;
                 Ok(Type::Enum(variants))
             }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -96,6 +96,8 @@ pub enum Type {
     Amount,
     AccountAddress,
     ContractAddress,
+    Timestamp,
+    Duration,
     Pair(Box<Type>, Box<Type>),
     List(SizeLength, Box<Type>),
     Set(SizeLength, Box<Type>),
@@ -157,6 +159,12 @@ impl SchemaType for AccountAddress {
 }
 impl SchemaType for ContractAddress {
     fn get_type() -> Type { Type::ContractAddress }
+}
+impl SchemaType for Timestamp {
+    fn get_type() -> Type { Type::Timestamp }
+}
+impl SchemaType for Duration {
+    fn get_type() -> Type { Type::Duration }
 }
 impl<T: SchemaType> SchemaType for Option<T> {
     fn get_type() -> Type {
@@ -366,38 +374,44 @@ impl Serial for Type {
             Type::ContractAddress => {
                 out.write_u8(12)?;
             }
-            Type::Pair(left, right) => {
+            Type::Timestamp => {
                 out.write_u8(13)?;
+            }
+            Type::Duration => {
+                out.write_u8(14)?;
+            }
+            Type::Pair(left, right) => {
+                out.write_u8(15)?;
                 left.serial(out)?;
                 right.serial(out)?;
             }
             Type::List(len_size, ty) => {
-                out.write_u8(14)?;
+                out.write_u8(16)?;
                 len_size.serial(out)?;
                 ty.serial(out)?;
             }
             Type::Set(len_size, ty) => {
-                out.write_u8(15)?;
+                out.write_u8(17)?;
                 len_size.serial(out)?;
                 ty.serial(out)?;
             }
             Type::Map(len_size, key, value) => {
-                out.write_u8(16)?;
+                out.write_u8(18)?;
                 len_size.serial(out)?;
                 key.serial(out)?;
                 value.serial(out)?;
             }
             Type::Array(len, ty) => {
-                out.write_u8(17)?;
+                out.write_u8(19)?;
                 len.serial(out)?;
                 ty.serial(out)?;
             }
             Type::Struct(fields) => {
-                out.write_u8(18)?;
+                out.write_u8(20)?;
                 fields.serial(out)?;
             }
             Type::Enum(fields) => {
-                out.write_u8(19)?;
+                out.write_u8(21)?;
                 fields.serial(out)?;
             }
         }
@@ -582,6 +596,14 @@ mod impls {
                 Type::ContractAddress => {
                     let address = ContractAddress::deserial(source)?;
                     Ok(Value::String(address.to_string()))
+                }
+                Type::Timestamp => {
+                    let timestamp = Timestamp::deserial(source)?;
+                    Ok(Value::String(timestamp.to_string()))
+                }
+                Type::Duration => {
+                    let duration = Duration::deserial(source)?;
+                    Ok(Value::String(duration.to_string()))
                 }
                 Type::Pair(left_type, right_type) => {
                     let left = left_type.to_json(source)?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -564,11 +564,11 @@ impl str::FromStr for Duration {
 impl fmt::Display for Duration {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let days = self.days();
-        let hours = Duration::from_millis(self.millis() % 1000 * 60 * 60 * 24).hours();
-        let minutes = Duration::from_millis(self.millis() % 1000 * 60 * 60).minutes();
-        let seconds = Duration::from_millis(self.millis() % 1000 * 60).seconds();
+        let hours = Duration::from_millis(self.millis() % (1000 * 60 * 60 * 24)).hours();
+        let minutes = Duration::from_millis(self.millis() % (1000 * 60 * 60)).minutes();
+        let seconds = Duration::from_millis(self.millis() % (1000 * 60)).seconds();
         let milliseconds = Duration::from_millis(self.millis() % 1000).millis();
-        write!(formatter, "{} {} {} {} {}", days, hours, minutes, seconds, milliseconds)
+        write!(formatter, "{}d {}h {}m {}s {}ms", days, hours, minutes, seconds, milliseconds)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -382,7 +382,7 @@ impl str::FromStr for Timestamp {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use convert::TryInto;
-        let datetime = chrono::DateTime::parse_from_rfc3339(s).map_err(|e| ParseTimestampError::ParseError(e))?;
+        let datetime = chrono::DateTime::parse_from_rfc3339(s).map_err(ParseTimestampError::ParseError)?;
         let millis = datetime.timestamp_millis().try_into().map_err(|_| ParseTimestampError::BeforeUnixEpoch)?;
         Ok(Timestamp::from_timestamp_millis(millis))
     }
@@ -563,13 +563,13 @@ impl str::FromStr for Duration {
 }
 
 impl fmt::Display for Duration {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let d = self.days();
-        let h = Duration::from_millis(self.millis() % 1000 * 60 * 60 * 24).hours();
-        let m = Duration::from_millis(self.millis() % 1000 * 60 * 60).minutes();
-        let s = Duration::from_millis(self.millis() % 1000 * 60).seconds();
-        let ms = Duration::from_millis(self.millis() % 1000).millis();
-        write!(f, "{} {} {} {} {}", d, h, m, s, ms)
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let days = self.days();
+        let hours = Duration::from_millis(self.millis() % 1000 * 60 * 60 * 24).hours();
+        let minutes = Duration::from_millis(self.millis() % 1000 * 60 * 60).minutes();
+        let seconds = Duration::from_millis(self.millis() % 1000 * 60).seconds();
+        let milliseconds = Duration::from_millis(self.millis() % 1000).millis();
+        write!(formatter, "{} {} {} {} {}", days, hours, minutes, seconds, milliseconds)
     }
 }
 
@@ -617,7 +617,7 @@ pub type BlockHeight = u64;
 pub type FinalizedHeight = u64;
 
 /// Time at the beginning of the current slot, in miliseconds.
-pub type SlotTime = u64;
+pub type SlotTime = Timestamp;
 
 /// Chain metadata accessible to both receive and init methods.
 #[cfg_attr(

--- a/src/types.rs
+++ b/src/types.rs
@@ -317,15 +317,13 @@ impl Timestamp {
     #[inline(always)]
     pub fn from_timestamp_millis(milliseconds: u64) -> Self {
         Self {
-            milliseconds
+            milliseconds,
         }
     }
 
     /// Get milliseconds since unix epoch.
     #[inline(always)]
-    pub fn timestamp_millis(&self) -> u64 {
-        self.milliseconds
-    }
+    pub fn timestamp_millis(&self) -> u64 { self.milliseconds }
 
     /// Add duration to timestamp. Returns `None` instead of overflowing.
     #[inline(always)]
@@ -362,7 +360,7 @@ impl Timestamp {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ParseTimestampError {
     ParseError(chrono::format::ParseError),
-    BeforeUnixEpoch
+    BeforeUnixEpoch,
 }
 
 #[cfg(feature = "derive-serde")]
@@ -382,8 +380,12 @@ impl str::FromStr for Timestamp {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use convert::TryInto;
-        let datetime = chrono::DateTime::parse_from_rfc3339(s).map_err(ParseTimestampError::ParseError)?;
-        let millis = datetime.timestamp_millis().try_into().map_err(|_| ParseTimestampError::BeforeUnixEpoch)?;
+        let datetime =
+            chrono::DateTime::parse_from_rfc3339(s).map_err(ParseTimestampError::ParseError)?;
+        let millis = datetime
+            .timestamp_millis()
+            .try_into()
+            .map_err(|_| ParseTimestampError::BeforeUnixEpoch)?;
         Ok(Timestamp::from_timestamp_millis(millis))
     }
 }
@@ -428,63 +430,45 @@ impl Duration {
     #[inline(always)]
     pub fn from_millis(milliseconds: u64) -> Self {
         Self {
-            milliseconds
+            milliseconds,
         }
     }
 
     /// Construct duration from seconds.
     #[inline(always)]
-    pub fn from_seconds(seconds: u64) -> Self {
-        Self::from_millis(seconds * 1000)
-    }
+    pub fn from_seconds(seconds: u64) -> Self { Self::from_millis(seconds * 1000) }
 
     /// Construct duration from minutes.
     #[inline(always)]
-    pub fn from_minutes(minutes: u64) -> Self {
-        Self::from_millis(minutes * 1000 * 60)
-    }
+    pub fn from_minutes(minutes: u64) -> Self { Self::from_millis(minutes * 1000 * 60) }
 
     /// Construct duration from hours.
     #[inline(always)]
-    pub fn from_hours(hours: u64) -> Self {
-        Self::from_millis(hours * 1000 * 60 * 60)
-    }
+    pub fn from_hours(hours: u64) -> Self { Self::from_millis(hours * 1000 * 60 * 60) }
 
     /// Construct duration from days.
     #[inline(always)]
-    pub fn from_days(days: u64) -> Self {
-        Self::from_millis(days * 1000 * 60 * 60 * 24)
-    }
+    pub fn from_days(days: u64) -> Self { Self::from_millis(days * 1000 * 60 * 60 * 24) }
 
     /// Get number of milliseconds in the duration.
     #[inline(always)]
-    pub fn millis(&self) -> u64 {
-        self.milliseconds
-    }
+    pub fn millis(&self) -> u64 { self.milliseconds }
 
     /// Get number of seconds in the duration.
     #[inline(always)]
-    pub fn seconds(&self) -> u64 {
-        self.milliseconds / 1000
-    }
+    pub fn seconds(&self) -> u64 { self.milliseconds / 1000 }
 
     /// Get number of minutes in the duration.
     #[inline(always)]
-    pub fn minutes(&self) -> u64 {
-        self.milliseconds / (1000 * 60)
-    }
+    pub fn minutes(&self) -> u64 { self.milliseconds / (1000 * 60) }
 
     /// Get number of hours in the duration.
     #[inline(always)]
-    pub fn hours(&self) -> u64 {
-        self.milliseconds / (1000 * 60 * 60)
-    }
+    pub fn hours(&self) -> u64 { self.milliseconds / (1000 * 60 * 60) }
 
     /// Get number of days in the duration.
     #[inline(always)]
-    pub fn days(&self) -> u64 {
-        self.milliseconds / (1000 * 60 * 60 * 24)
-    }
+    pub fn days(&self) -> u64 { self.milliseconds / (1000 * 60 * 60 * 24) }
 
     /// Add duration. Returns `None` instead of overflowing.
     #[inline(always)]
@@ -503,9 +487,8 @@ impl Duration {
 pub enum ParseDurationError {
     MissingUnit,
     FailedParsingNumber,
-    InvalidUnit(String)
+    InvalidUnit(String),
 }
-
 
 impl fmt::Display for ParseDurationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -553,7 +536,7 @@ impl str::FromStr for Duration {
                 "m" => 1000 * 60,
                 "h" => 1000 * 60 * 60,
                 "d" => 1000 * 60 * 60 * 24,
-                other => return Err(InvalidUnit(String::from(other)))
+                other => return Err(InvalidUnit(String::from(other))),
             };
             duration += n * unit;
         }
@@ -720,10 +703,9 @@ mod policy_json {
                 }
                 let dt = chrono::naive::NaiveDate::from_ymd(i32::from(year), u32::from(month), 1)
                     .and_hms(0, 0, 0);
-                let timestamp: u64 =
-                    dt.timestamp_millis().try_into().map_err(|_| {
-                        serde::de::Error::custom("Times before 1970 are not supported.")
-                    })?;
+                let timestamp: u64 = dt.timestamp_millis().try_into().map_err(|_| {
+                    serde::de::Error::custom("Times before 1970 are not supported.")
+                })?;
                 Ok(timestamp)
             };
 
@@ -951,6 +933,13 @@ mod test {
     #[test]
     fn test_duration_from_string_simple() {
         let duration = Duration::from_str("12d 1h 39s 3m 2h").unwrap();
-        assert_eq!(duration.millis(), 1000*60*60*24*12 + 1000*60*60*1 + 1000*39+ 1000*60*3 + 1000*60*60*2)
+        assert_eq!(
+            duration.millis(),
+            1000 * 60 * 60 * 24 * 12 // 12d
+                + 1000 * 60 * 60     // 1h
+                + 1000 * 39          // 39s
+                + 1000 * 60 * 3      // 3m
+                + 1000 * 60 * 60 * 2 // 2h
+        )
     }
 }


### PR DESCRIPTION
Introduces transparent types for Timestamp and Duration, and extends the schema to include these.