### PR TITLE
Remove values from chain context.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-contracts-common"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Concordium <info@concordium.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -285,24 +285,13 @@ impl Deserial for Address {
 }
 
 impl Serial for ChainMetadata {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        self.slot_number.serial(out)?;
-        self.block_height.serial(out)?;
-        self.finalized_height.serial(out)?;
-        self.slot_time.serial(out)
-    }
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.slot_time.serial(out) }
 }
 
 impl Deserial for ChainMetadata {
     fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
-        let slot_number = source.get()?;
-        let block_height = source.get()?;
-        let finalized_height = source.get()?;
         let slot_time = source.get()?;
         Ok(Self {
-            slot_number,
-            block_height,
-            finalized_height,
             slot_time,
         })
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -623,10 +623,7 @@ pub type SlotTime = Timestamp;
     serde(rename_all = "camelCase")
 )]
 pub struct ChainMetadata {
-    pub slot_number:      SlotNumber,
-    pub block_height:     BlockHeight,
-    pub finalized_height: FinalizedHeight,
-    pub slot_time:        SlotTime,
+    pub slot_time: SlotTime,
 }
 
 /// Add offset tracking inside a data structure.


### PR DESCRIPTION
Slot time can be used instead of block height and slot number for use-cases.
It is unclear how one would use the finalized height for anything meaningful.