### PR TITLE
CB-1203: Contract and receive names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 # Unreleased changes
 
 - Add String to the schema.
+- Add ContractName and ReceiveName to schema.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,5 @@
+/// Must stay in sync with wasm-transform/src/constants.rs
+/// Maximum size of function names.
+pub(crate) const MAX_FUNC_NAME_SIZE: usize = 100;
+
+pub(crate) static MAX_PREALLOCATED_CAPACITY: usize = 4096;

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -294,6 +294,48 @@ impl Deserial for Address {
     }
 }
 
+impl<'a> Serial for ContractName<'a> {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        let name = self.get_chain_name();
+        let len = name.len() as u32;
+        len.serial(out)?;
+        serial_vector_no_length(name.as_bytes(), out)
+    }
+}
+
+impl Serial for OwnedContractName {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        self.get_chain_name().serial(out)
+    }
+}
+
+impl Deserial for OwnedContractName {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        Ok(OwnedContractName::new(source.get()?))
+    }
+}
+
+impl<'a> Serial for ReceiveName<'a> {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        let name = self.get_chain_name();
+        let len = name.len() as u32;
+        len.serial(out)?;
+        serial_vector_no_length(name.as_bytes(), out)
+    }
+}
+
+impl Serial for OwnedReceiveName {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        self.get_chain_name().serial(out)
+    }
+}
+
+impl Deserial for OwnedReceiveName {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        Ok(OwnedReceiveName::new(source.get()?))
+    }
+}
+
 impl Serial for ChainMetadata {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.slot_time.serial(out) }
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -311,7 +311,9 @@ impl Serial for OwnedContractName {
 
 impl Deserial for OwnedContractName {
     fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
-        Ok(OwnedContractName::new(source.get()?))
+        let owned_contract_name =
+            OwnedContractName::new(source.get()?).map_err(|_| ParseError::default())?;
+        Ok(owned_contract_name)
     }
 }
 
@@ -332,7 +334,9 @@ impl Serial for OwnedReceiveName {
 
 impl Deserial for OwnedReceiveName {
     fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
-        Ok(OwnedReceiveName::new(source.get()?))
+        let owned_receive_name =
+            OwnedReceiveName::new(source.get()?).map_err(|_| ParseError::default())?;
+        Ok(owned_receive_name)
     }
 }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,4 +1,4 @@
-use crate::{traits::*, types::*};
+use crate::{constants::*, traits::*, types::*};
 
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, collections::*, string::String, vec::Vec};
@@ -6,8 +6,6 @@ use alloc::{boxed::Box, collections::*, string::String, vec::Vec};
 use core::{marker, mem::MaybeUninit, slice};
 #[cfg(feature = "std")]
 use std::{collections::*, marker, mem::MaybeUninit, slice};
-
-pub(crate) static MAX_PREALLOCATED_CAPACITY: usize = 4096;
 
 /// Apply the given macro to each of the elements in the list
 /// For example, `repeat_macro!(println, "foo", "bar")` is equivalent to

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -188,10 +188,16 @@ impl Deserial for Duration {
 
 /// Serialized by writing an `u32` representing the number of bytes for a
 /// utf8-encoding of the string, then writing the bytes. Similar to `Vec<_>`.
-impl Serial for String {
+impl Serial for &str {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        self.bytes().collect::<Vec<_>>().serial(out)
+        self.as_bytes().to_vec().serial(out)
     }
+}
+
+/// Serialized by writing an `u32` representing the number of bytes for a
+/// utf8-encoding of the string, then writing the bytes. Similar to `&str`.
+impl Serial for String {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.as_str().serial(out) }
 }
 
 /// Deserial by reading an `u32` representing the number of bytes, then takes
@@ -322,17 +328,12 @@ impl Deserial for Address {
 
 impl<'a> Serial for ContractName<'a> {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        let name = self.get_chain_name();
-        let len = name.len() as u32;
-        len.serial(out)?;
-        serial_vector_no_length(name.as_bytes(), out)
+        self.get_chain_name().serial(out)
     }
 }
 
 impl Serial for OwnedContractName {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        self.get_chain_name().serial(out)
-    }
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.as_ref().serial(out) }
 }
 
 impl Deserial for OwnedContractName {
@@ -345,17 +346,12 @@ impl Deserial for OwnedContractName {
 
 impl<'a> Serial for ReceiveName<'a> {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        let name = self.get_chain_name();
-        let len = name.len() as u32;
-        len.serial(out)?;
-        serial_vector_no_length(name.as_bytes(), out)
+        self.get_chain_name().serial(out)
     }
 }
 
 impl Serial for OwnedReceiveName {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        self.get_chain_name().serial(out)
-    }
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.as_ref().serial(out) }
 }
 
 impl Deserial for OwnedReceiveName {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ extern crate alloc;
 mod traits;
 #[macro_use]
 mod impls;
+mod constants;
 pub mod schema;
 mod types;
 pub use impls::*;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -723,13 +723,15 @@ mod impls {
                     Ok(Value::String(string))
                 }
                 Type::ContractName(size_len) => {
-                    let contract_name = OwnedContractName::new(deserial_string(source, size_len)?);
+                    let contract_name = OwnedContractName::new(deserial_string(source, size_len)?)
+                        .map_err(|_| ParseError::default())?;
                     let name_without_init =
                         contract_name.contract_name().ok_or_else(ParseError::default)?;
                     Ok(json!({ "contract": name_without_init }))
                 }
                 Type::ReceiveName(size_len) => {
-                    let receive_name = OwnedReceiveName::new(deserial_string(source, size_len)?);
+                    let receive_name = OwnedReceiveName::new(deserial_string(source, size_len)?)
+                        .map_err(|_| ParseError::default())?;
                     let contract_name =
                         receive_name.contract_name().ok_or_else(ParseError::default)?;
                     let func_name = receive_name.func_name().ok_or_else(ParseError::default)?;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -498,6 +498,7 @@ impl Deserial for Type {
 #[cfg(feature = "derive-serde")]
 mod impls {
     use super::*;
+    use crate::constants::*;
     impl Fields {
         pub fn to_json<R: Read>(&self, source: &mut R) -> ParseResult<serde_json::Value> {
             use serde_json::*;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -206,11 +206,11 @@ impl SchemaType for String {
 }
 
 impl SchemaType for OwnedContractName {
-    fn get_type() -> Type { Type::ContractName(SizeLength::U32) }
+    fn get_type() -> Type { Type::ContractName(SizeLength::U16) }
 }
 
 impl SchemaType for OwnedReceiveName {
-    fn get_type() -> Type { Type::ReceiveName(SizeLength::U32) }
+    fn get_type() -> Type { Type::ReceiveName(SizeLength::U16) }
 }
 
 macro_rules! schema_type_array_x {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 use crate::constants;
 #[cfg(not(feature = "std"))]
-use alloc::{string::String, vec::Vec};
+use alloc::{string::String, string::ToString, vec::Vec};
 #[cfg(not(feature = "std"))]
 use core::{convert, fmt, iter, ops, str};
 #[cfg(feature = "std")]
@@ -704,11 +704,15 @@ impl<'a> ReceiveName<'a> {
 
     /// Get receive name used on chain: "<contract_name>.<func_name>".
     pub fn get_chain_name(&self) -> &str { self.0 }
+
+    /// Convert a `ReceiveName` to its owned counterpart. This is an expensive
+    /// operation that requires memory allocation.
+    pub fn to_owned(&self) -> OwnedReceiveName { OwnedReceiveName(self.0.to_string()) }
 }
 
 /// A receive name (owned version). Expected format:
 /// "<contract_name>.<func_name>".
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub struct OwnedReceiveName(String);
 
 impl OwnedReceiveName {
@@ -760,7 +764,7 @@ impl fmt::Display for NewReceiveNameError {
         use NewReceiveNameError::*;
         match self {
             MissingDotSeparator => {
-                write!(f, "Receive names have the format '<contract_name>.<func_name>'.")
+                f.write_str("Receive names have the format '<contract_name>.<func_name>'.")
             }
             TooLong => {
                 write!(f, "Receive names have a max length of {}", constants::MAX_FUNC_NAME_SIZE)
@@ -1028,7 +1032,7 @@ pub mod attributes {
 /// }
 ///
 /// #[receive(contract = "mycontract", name="some_receive_name")]
-/// fn contract_receive<R: HasReceiveContext<()>, L: HasLogger, A: HasActions>(
+/// fn contract_receive<R: HasReceiveContext, L: HasLogger, A: HasActions>(
 ///     ctx: &R,
 ///     receive_amount: Amount,
 ///     logger: &mut L,

--- a/src/types.rs
+++ b/src/types.rs
@@ -603,9 +603,20 @@ pub enum Address {
 pub struct ContractName<'a>(&'a str);
 
 impl<'a> ContractName<'a> {
-    /// Create a new ContractName. Expected format: "init_<contract_name>".
+    /// Create a new ContractName and check the format. Expected format:
+    /// "init_<contract_name>".
     #[inline(always)]
-    pub fn new(name: &'a str) -> Self { ContractName(name) }
+    pub fn new(name: &'a str) -> Result<Self, NewContractNameError> {
+        if !name.starts_with("init_") {
+            return Err(NewContractNameError::MissingInitPrefix);
+        }
+        Ok(ContractName(name))
+    }
+
+    /// Create a new ContractName without checking the format. Expected format:
+    /// "init_<contract_name>".
+    #[inline(always)]
+    pub fn unchecked_new(name: &'a str) -> Self { ContractName(name) }
 
     /// Get contract name used on chain: "init_<contract_name>".
     #[inline(always)]
@@ -617,9 +628,20 @@ impl<'a> ContractName<'a> {
 pub struct OwnedContractName(String);
 
 impl OwnedContractName {
-    /// Create a new OwnedContractName. Expected format: "init_<contract_name>".
+    /// Create a new OwnedContractName and check the format. Expected format:
+    /// "init_<contract_name>".
     #[inline(always)]
-    pub fn new(name: String) -> Self { OwnedContractName(name) }
+    pub fn new(name: String) -> Result<Self, NewContractNameError> {
+        if !name.starts_with("init_") {
+            return Err(NewContractNameError::MissingInitPrefix);
+        }
+        Ok(OwnedContractName(name))
+    }
+
+    /// Create a new OwnedContractName without checking the format. Expected
+    /// format: "init_<contract_name>".
+    #[inline(always)]
+    pub fn unchecked_new(name: String) -> Self { OwnedContractName(name) }
 
     /// Get contract name used on chain: "init_<contract_name>".
     #[inline(always)]
@@ -634,14 +656,37 @@ impl OwnedContractName {
     pub fn as_ref(&self) -> ContractName { ContractName(self.get_chain_name().as_str()) }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NewContractNameError {
+    MissingInitPrefix,
+}
+
+impl fmt::Display for NewContractNameError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use NewContractNameError::*;
+        match self {
+            MissingInitPrefix => write!(f, "Contract names have the format 'init_<contract_name>'"),
+        }
+    }
+}
+
 /// A receive name. Expected format: "<contract_name>.<func_name>".
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
 pub struct ReceiveName<'a>(&'a str);
 
 impl<'a> ReceiveName<'a> {
-    /// Create a new ReceiveName. Expected format:
+    /// Create a new ReceiveName and check the format. Expected format:
     /// "<contract_name>.<func_name>".
-    pub fn new(name: &'a str) -> Self { ReceiveName(name) }
+    pub fn new(name: &'a str) -> Result<Self, NewReceiveNameError> {
+        if !name.contains('.') {
+            return Err(NewReceiveNameError::MissingDotSeparator);
+        }
+        Ok(ReceiveName(name))
+    }
+
+    /// Create a new ReceiveName without checking the format. Expected format:
+    /// "<contract_name>.<func_name>".
+    pub fn unchecked_new(name: &'a str) -> Self { ReceiveName(name) }
 
     /// Get receive name used on chain: "<contract_name>.<func_name>".
     pub fn get_chain_name(&self) -> &str { self.0 }
@@ -653,9 +698,18 @@ impl<'a> ReceiveName<'a> {
 pub struct OwnedReceiveName(String);
 
 impl OwnedReceiveName {
-    /// Create a new OwnedReceiveName. Expected format:
+    /// Create a new OwnedReceiveName and check the format. Expected format:
     /// "<contract_name>.<func_name>".
-    pub fn new(name: String) -> Self { OwnedReceiveName(name) }
+    pub fn new(name: String) -> Result<Self, NewReceiveNameError> {
+        if !name.contains('.') {
+            return Err(NewReceiveNameError::MissingDotSeparator);
+        }
+        Ok(OwnedReceiveName(name))
+    }
+
+    /// Create a new OwnedReceiveName without checking the format. Expected
+    /// format: "<contract_name>.<func_name>".
+    pub fn unchecked_new(name: String) -> Self { OwnedReceiveName(name) }
 
     /// Get receive name used on chain: "<contract_name>.<func_name>".
     pub fn get_chain_name(&self) -> &String { &self.0 }
@@ -676,6 +730,22 @@ impl OwnedReceiveName {
 
     /// Convert to ReceiveName by reference.
     pub fn as_ref(&self) -> ReceiveName { ReceiveName(self.0.as_str()) }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NewReceiveNameError {
+    MissingDotSeparator,
+}
+
+impl fmt::Display for NewReceiveNameError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use NewReceiveNameError::*;
+        match self {
+            MissingDotSeparator => {
+                write!(f, "Receive names have the format '<contract_name>.<func_name>'.")
+            }
+        }
+    }
 }
 
 /// Genesis block has slot number 0, and otherwise it is always the case that a

--- a/src/types.rs
+++ b/src/types.rs
@@ -598,6 +598,86 @@ pub enum Address {
     Contract(ContractAddress),
 }
 
+/// A contract name. Expected format: "init_<contract_name>".
+#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+pub struct ContractName<'a>(&'a str);
+
+impl<'a> ContractName<'a> {
+    /// Create a new ContractName. Expected format: "init_<contract_name>".
+    #[inline(always)]
+    pub fn new(name: &'a str) -> Self { ContractName(name) }
+
+    /// Get contract name used on chain: "init_<contract_name>".
+    #[inline(always)]
+    pub fn get_chain_name(&self) -> &str { self.0 }
+}
+
+/// A contract name (owned version). Expected format: "init_<contract_name>".
+#[derive(Eq, PartialEq, Debug)]
+pub struct OwnedContractName(String);
+
+impl OwnedContractName {
+    /// Create a new OwnedContractName. Expected format: "init_<contract_name>".
+    #[inline(always)]
+    pub fn new(name: String) -> Self { OwnedContractName(name) }
+
+    /// Get contract name used on chain: "init_<contract_name>".
+    #[inline(always)]
+    pub fn get_chain_name(&self) -> &String { &self.0 }
+
+    /// Try to extract the contract name by removing the "init_" prefix.
+    #[inline(always)]
+    pub fn contract_name(&self) -> Option<&str> { self.get_chain_name().strip_prefix("init_") }
+
+    /// Convert to ContractName by reference.
+    #[inline(always)]
+    pub fn as_ref(&self) -> ContractName { ContractName(self.get_chain_name().as_str()) }
+}
+
+/// A receive name. Expected format: "<contract_name>.<func_name>".
+#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+pub struct ReceiveName<'a>(&'a str);
+
+impl<'a> ReceiveName<'a> {
+    /// Create a new ReceiveName. Expected format:
+    /// "<contract_name>.<func_name>".
+    pub fn new(name: &'a str) -> Self { ReceiveName(name) }
+
+    /// Get receive name used on chain: "<contract_name>.<func_name>".
+    pub fn get_chain_name(&self) -> &str { self.0 }
+}
+
+/// A receive name (owned version). Expected format:
+/// "<contract_name>.<func_name>".
+#[derive(Eq, PartialEq, Debug)]
+pub struct OwnedReceiveName(String);
+
+impl OwnedReceiveName {
+    /// Create a new OwnedReceiveName. Expected format:
+    /// "<contract_name>.<func_name>".
+    pub fn new(name: String) -> Self { OwnedReceiveName(name) }
+
+    /// Get receive name used on chain: "<contract_name>.<func_name>".
+    pub fn get_chain_name(&self) -> &String { &self.0 }
+
+    /// Try to extract the contract name by splitting at the first dot.
+    pub fn contract_name(&self) -> Option<&str> { self.get_name_parts().map(|parts| parts.0) }
+
+    /// Try to extract the func name by splitting at the first dot.
+    pub fn func_name(&self) -> Option<&str> { self.get_name_parts().map(|parts| parts.1) }
+
+    /// Try to extract (contract_name, func_name) by splitting at the first dot.
+    fn get_name_parts(&self) -> Option<(&str, &str)> {
+        let mut splitter = self.get_chain_name().splitn(2, '.');
+        let contract = splitter.next()?;
+        let func = splitter.next()?;
+        Some((contract, func))
+    }
+
+    /// Convert to ReceiveName by reference.
+    pub fn as_ref(&self) -> ReceiveName { ReceiveName(self.0.as_str()) }
+}
+
 /// Genesis block has slot number 0, and otherwise it is always the case that a
 /// parent of a block has a slot number strictly less than the block itself.
 /// However in contrast to `BlockHeight`, slot numbers are not strictly

--- a/src/types.rs
+++ b/src/types.rs
@@ -1118,4 +1118,81 @@ mod test {
                 + 1000 * 60 * 60 * 2 // 2h
         )
     }
+
+    #[test]
+    fn test_valid_new_contract_name() {
+        let contract_name = ContractName::new("init_contract");
+        assert!(contract_name.is_ok())
+    }
+
+    #[test]
+    fn test_invalid_new_contract_name() {
+        let contract_name = ContractName::new("no_init_prefix");
+        assert!(contract_name.is_err())
+    }
+
+    #[test]
+    fn test_getters_for_contract_name() {
+        let expected_chain_name = "init_contract";
+        let contract_name = ContractName::new(expected_chain_name).unwrap();
+        assert_eq!(contract_name.get_chain_name(), expected_chain_name);
+    }
+
+    #[test]
+    fn test_valid_new_owned_contract_name() {
+        let contract_name = OwnedContractName::new("init_contract".to_string());
+        assert!(contract_name.is_ok())
+    }
+
+    #[test]
+    fn test_invalid_new_owned_contract_name() {
+        let contract_name = OwnedContractName::new("no_init_prefix".to_string());
+        assert!(contract_name.is_err())
+    }
+
+    #[test]
+    fn test_getters_for_owned_contract_name() {
+        let contract_name = OwnedContractName::new("init_contract".to_string()).unwrap();
+        assert_eq!(contract_name.get_chain_name(), "init_contract");
+        assert_eq!(contract_name.contract_name(), Some("contract"));
+    }
+
+    #[test]
+    fn test_valid_new_receive_name() {
+        let receive_name = ReceiveName::new("contract.receive");
+        assert!(receive_name.is_ok())
+    }
+
+    #[test]
+    fn test_invalid_new_receive_name() {
+        let receive_name = ReceiveName::new("no_dot_separator");
+        assert!(receive_name.is_err())
+    }
+
+    #[test]
+    fn test_getters_for_receive_name() {
+        let expected_chain_name = "contract.receive";
+        let receive_name = ReceiveName::new(expected_chain_name).unwrap();
+        assert_eq!(receive_name.get_chain_name(), expected_chain_name);
+    }
+
+    #[test]
+    fn test_valid_new_owned_receive_name() {
+        let receive_name = OwnedReceiveName::new("contract.receive".to_string());
+        assert!(receive_name.is_ok())
+    }
+
+    #[test]
+    fn test_invalid_new_owned_receive_name() {
+        let receive_name = OwnedReceiveName::new("no_dot_separator".to_string());
+        assert!(receive_name.is_err())
+    }
+
+    #[test]
+    fn test_getters_for_owned_receive_name() {
+        let receive_name = OwnedReceiveName::new("contract.receive".to_string()).unwrap();
+        assert_eq!(receive_name.get_chain_name(), "contract.receive");
+        assert_eq!(receive_name.contract_name(), Some("contract"));
+        assert_eq!(receive_name.func_name(), Some("receive"));
+    }
 }


### PR DESCRIPTION
Closes CB-1203.

Adds support for sending contract names and receive names as parameters.

Adds the schema types:
- `ContractName` 
- `ReceiveName`

Also adds the following data types:
- `ContractName`
- `OwnedContractName` (implements `SchemaType`)
- `ReceiveName`
- `OwnedReceiveName` (implements `SchemaType`)

The owned versions can be converted into their counterparts with `as_ref()`.

Related:
https://gitlab.com/Concordium/smart-contracts/-/merge_requests/125
https://gitlab.com/Concordium/concordium-client/-/merge_requests/291
https://github.com/Concordium/concordium-rust-smart-contracts/pull/25