### PR TITLE
Features for fuzzing support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ homepage = "https://github.com/Concordium/concordium-contracts-common"
 repository = "https://github.com/Concordium/concordium-contracts-common"
 readme = "README.md"
 
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
+arbitrary = { version = "0.4", features = ["derive"], optional = true }
 
 [dependencies.serde]
 optional = true
@@ -33,9 +33,11 @@ version = "0.1"
 [features]
 default = ["std"]
 
-std = []
+std = ["arbitrary"]
 
 derive-serde = ["serde", "serde_json", "std", "base58check", "chrono"]
+
+fuzz = []
 
 [lib]
 # Since we don't define an allocator in this crate, we can only produce an rlib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/Concordium/concordium-contracts-common"
 repository = "https://github.com/Concordium/concordium-contracts-common"
 readme = "README.md"
 
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 arbitrary = { version = "0.4", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ std = ["arbitrary"]
 
 derive-serde = ["serde", "serde_json", "std", "base58check", "chrono"]
 
-fuzz = []
+fuzz = ["derive-serde"]
 
 [lib]
 # Since we don't define an allocator in this crate, we can only produce an rlib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,11 @@ version = "0.1"
 [features]
 default = ["std"]
 
-std = ["arbitrary"]
+std = []
 
 derive-serde = ["serde", "serde_json", "std", "base58check", "chrono"]
 
-fuzz = ["derive-serde"]
+fuzz = ["derive-serde", "arbitrary"]
 
 [lib]
 # Since we don't define an allocator in this crate, we can only produce an rlib

--- a/src/types.rs
+++ b/src/types.rs
@@ -882,9 +882,8 @@ impl<'de> SerdeDeserialize<'de> for OwnedPolicy {
 
 #[cfg(feature = "derive-serde")]
 mod policy_json {
-    use convert::{TryFrom, TryInto};
-
     use super::*;
+    use convert::{TryFrom, TryInto};
 
     pub(crate) struct OwnedPolicyVisitor;
 
@@ -987,7 +986,6 @@ mod policy_json {
 pub mod attributes {
     // NB: These names and values must match the rest of the Concordium ecosystem.
     use super::{convert, AttributeTag};
-
     pub const FIRST_NAME: AttributeTag = AttributeTag(0u8);
     pub const LAST_NAME: AttributeTag = AttributeTag(1u8);
     pub const SEX: AttributeTag = AttributeTag(2u8);
@@ -1064,13 +1062,11 @@ pub type ParseResult<A> = Result<A, ParseError>;
 
 #[cfg(feature = "derive-serde")]
 mod serde_impl {
-    use std::fmt;
-
-    use base58check::*;
-    use serde::{de, de::Visitor, Deserializer, Serializer};
-
     // FIXME: This is duplicated from crypto/id/types.
     use super::*;
+    use base58check::*;
+    use serde::{de, de::Visitor, Deserializer, Serializer};
+    use std::fmt;
 
     // Parse from string assuming base58 check encoding.
     impl str::FromStr for AccountAddress {
@@ -1142,9 +1138,8 @@ mod serde_impl {
 
 #[cfg(test)]
 mod test {
-    use std::str::FromStr;
-
     use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn test_duration_from_string_simple() {


### PR DESCRIPTION
Adding `fuzz` feature that allows the `wasm-chain-integration` repository to support fuzzing. For that, we derive `Debug` and `Arbitrary` for a bunch of data types.