### PR TITLE
Unique validation functions for contract and receive names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased changes
+- Add public validation functions to contract and receive names
+- Add new cases for NewContractNameError and NewReceiveNameError
 
 ## concordium-contracts-common 0.4.0 (2021-05-12)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-contracts-common"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,6 @@
-/// Must stay in sync with wasm-transform/src/constants.rs
 /// Maximum size of function names.
-pub(crate) const MAX_FUNC_NAME_SIZE: usize = 100;
+/// A contract name is defined by its init name, so this also limits the size
+/// of contract names.
+pub const MAX_FUNC_NAME_SIZE: usize = 100;
 
 pub(crate) static MAX_PREALLOCATED_CAPACITY: usize = 4096;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ extern crate alloc;
 mod traits;
 #[macro_use]
 mod impls;
-mod constants;
+pub mod constants;
 pub mod schema;
 mod types;
 pub use impls::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -803,7 +803,7 @@ impl fmt::Display for NewReceiveNameError {
         use NewReceiveNameError::*;
         match self {
             MissingDotSeparator => {
-                write!(f, "Receive names have the format '<contract_name>.<func_name>'.")
+                f.write_str("Receive names have the format '<contract_name>.<func_name>'.")
             }
             TooLong => {
                 write!(f, "Receive names have a max length of {}", constants::MAX_FUNC_NAME_SIZE)

--- a/src/types.rs
+++ b/src/types.rs
@@ -628,7 +628,14 @@ impl<'a> ContractName<'a> {
     #[inline(always)]
     pub fn get_chain_name(&self) -> &str { self.0 }
 
-    /// Check whether a given contract name is valid.
+    /// Check whether the given string is a valid contract initialization
+    /// function name. This is the case if and only if
+    /// - the string is no more than [constants::MAX_FUNC_NAME_SIZE][m] bytes
+    /// - the string starts with `init_`
+    /// - the string __does not__ contain a `.`
+    /// - all characters are ascii alphanumeric or punctuation characters.
+    ///
+    /// [m]: ./constants/constant.MAX_FUNC_NAME_SIZE.html
     pub fn is_valid_contract_name(name: &str) -> Result<(), NewContractNameError> {
         if !name.starts_with("init_") {
             return Err(NewContractNameError::MissingInitPrefix);
@@ -725,7 +732,13 @@ impl<'a> ReceiveName<'a> {
     /// operation that requires memory allocation.
     pub fn to_owned(&self) -> OwnedReceiveName { OwnedReceiveName(self.0.to_string()) }
 
-    /// Check whether a receive name is valid.
+    /// Check whether the given string is a valid contract receive function
+    /// name. This is the case if and only if
+    /// - the string is no more than [constants::MAX_FUNC_NAME_SIZE][m] bytes
+    /// - the string __contains__ a `.`
+    /// - all characters are ascii alphanumeric or punctuation characters.
+    ///
+    /// [m]: ./constants/constant.MAX_FUNC_NAME_SIZE.html
     pub fn is_valid_receive_name(name: &str) -> Result<(), NewReceiveNameError> {
         if !name.contains('.') {
             return Err(NewReceiveNameError::MissingDotSeparator);


### PR DESCRIPTION
## Purpose

Contract and receive names were being validated with different functions. Now, I've combined them into one.

## Changes

- Move `MAX_FUNC_NAME_SIZE` from wasm-transform, as wasm-transform now depends on this repo (separate PR)
- Make the validation functions public
- Add some additional error variants, as they were missing from `NewContractNameError` and `ReceiveNameError`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.