### PR TITLE
Add helpers for serializing lengths of specific sizes

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -8,10 +8,18 @@ use crate::{impls::*, traits::*, types::*};
 use alloc::boxed::Box;
 #[cfg(not(feature = "std"))]
 use alloc::{collections::*, string::String, vec::Vec};
+#[cfg(not(feature = "std"))]
+use core::{
+    convert::{TryFrom, TryInto},
+    num::TryFromIntError,
+};
 /// Contract schema related types
 #[cfg(feature = "std")]
-use std::collections::*;
-use std::convert::{TryFrom, TryInto};
+use std::{
+    collections::*,
+    convert::{TryFrom, TryInto},
+    num::TryFromIntError,
+};
 
 /// The `SchemaType` trait provides means to generate a schema for structures.
 /// Schemas are used to make structures human readable and to avoid dealing
@@ -494,8 +502,8 @@ impl Deserial for Type {
     }
 }
 
-impl From<std::num::TryFromIntError> for ParseError {
-    fn from(_: std::num::TryFromIntError) -> Self { ParseError::default() }
+impl From<TryFromIntError> for ParseError {
+    fn from(_: TryFromIntError) -> Self { ParseError::default() }
 }
 
 /// Try to convert the `len` to the provided size and serialize it.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -512,11 +512,12 @@ pub fn serial_length<W: Write>(
     size_len: &SizeLength,
     out: &mut W,
 ) -> Result<(), W::Err> {
+    let to_w_err = |_| W::Err::default();
     match size_len {
-        SizeLength::U8 => u8::try_from(len).unwrap_or_default().serial(out)?,
-        SizeLength::U16 => u16::try_from(len).unwrap_or_default().serial(out)?,
-        SizeLength::U32 => u32::try_from(len).unwrap_or_default().serial(out)?,
-        SizeLength::U64 => u64::try_from(len).unwrap_or_default().serial(out)?,
+        SizeLength::U8 => u8::try_from(len).map_err(to_w_err)?.serial(out)?,
+        SizeLength::U16 => u16::try_from(len).map_err(to_w_err)?.serial(out)?,
+        SizeLength::U32 => u32::try_from(len).map_err(to_w_err)?.serial(out)?,
+        SizeLength::U64 => u64::try_from(len).map_err(to_w_err)?.serial(out)?,
     }
     Ok(())
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -201,8 +201,8 @@ pub trait Serial {
     fn serial<W: Write>(&self, _out: &mut W) -> Result<(), W::Err>;
 }
 
-/// The `Deserial` trait provides a means of reading structures from byte-sinks
-/// (`Read`).
+/// The `Deserial` trait provides a means of reading structures from
+/// byte-sources (`Read`).
 ///
 /// Can be derived using `#[derive(Deserial)]` for most cases.
 pub trait Deserial: Sized {


### PR DESCRIPTION
## Purpose

Add helper functions for serializing lengths of specific `size_lengths`.
Needed for https://github.com/Concordium/concordium-rust-smart-contracts/pull/39

## Changes

- Add helper functions for serializing lengths of specific `size_lengths`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
