### PR TITLE
Adding better support for hashmaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
 ## Unreleased changes
-- Add public validation functions to contract and receive names
-- Add new cases for NewContractNameError and NewReceiveNameError
+- Add public validation functions to contract and receive names.
+- Add new cases for NewContractNameError and NewReceiveNameError.
 - Implement `SchemaType` for `Address`.
 - Derive `PartialOrd` and `Ord` for `ContractAddress` and `Address`.
+- Derive `Hash` for `Amount`, `Timestamp`, `Duration`, `AccountAddress`, `ContractAddress`, `Address`, `ContractName`, `OwnedContractName`, `ReceiveName` and `OwnedReceiveName`.
+- Add `HashMap` and `HashSet` from the `hashbrown` crate to support `no-std`.
+- Make `HashMap` and `HashSet` default to the `fnv` hasher.
 
 ## concordium-contracts-common 0.4.0 (2021-05-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased changes
 - Add public validation functions to contract and receive names
 - Add new cases for NewContractNameError and NewReceiveNameError
+- Implement `SchemaType` for `Address`.
+- Derive `PartialOrd` and `Ord` for `ContractAddress` and `Address`.
 
 ## concordium-contracts-common 0.4.0 (2021-05-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Derive `Hash` for `Amount`, `Timestamp`, `Duration`, `AccountAddress`, `ContractAddress`, `Address`, `ContractName`, `OwnedContractName`, `ReceiveName` and `OwnedReceiveName`.
 - Add `HashMap` and `HashSet` from the `hashbrown` crate to support `no-std`.
 - Make `HashMap` and `HashSet` default to the `fnv` hasher.
-
+- Add functions for serializing and deserializing `HashMap` and `HashSet` without the length (`serial_hashmap_no_length`, `deserial_hashmap_no_length`, `deserial_hashset_no_length`, `deserial_hashset_no_length`).
 ## concordium-contracts-common 0.4.0 (2021-05-12)
 
 - Add String to the schema.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ readme = "README.md"
 arbitrary = { version = "0.4", features = ["derive"], optional = true }
 
 [dependencies.hashbrown]
-version = "0.11.2"
+version = "0.11"
 default-features = false
 
 [dependencies.fnv]
-version = "1.0.7"
+version = "1.0"
 default-features = false
 
 [dependencies.serde]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,14 @@ readme = "README.md"
 [dependencies]
 arbitrary = { version = "0.4", features = ["derive"], optional = true }
 
+[dependencies.hashbrown]
+version = "0.11.2"
+default-features = false
+
+[dependencies.fnv]
+version = "1.0.7"
+default-features = false
+
 [dependencies.serde]
 optional = true
 features = ["derive"]
@@ -34,7 +42,7 @@ version = "0.1"
 [features]
 default = ["std"]
 
-std = []
+std = ["fnv/std"]
 
 derive-serde = ["serde", "serde_json", "std", "base58check", "chrono"]
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -2,13 +2,12 @@ use crate::{constants::*, traits::*, types::*};
 
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, collections, string::String, vec::Vec};
+use collections::{BTreeMap, BTreeSet};
 #[cfg(not(feature = "std"))]
 use core::{hash, marker, mem::MaybeUninit, slice};
+use hash::Hash;
 #[cfg(feature = "std")]
 use std::{collections, hash, marker, mem::MaybeUninit, slice};
-
-use collections::{BTreeMap, BTreeSet};
-use hash::Hash;
 
 /// Apply the given macro to each of the elements in the list
 /// For example, `repeat_macro!(println, "foo", "bar")` is equivalent to

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -411,7 +411,7 @@ pub fn deserial_vector_no_length<R: Read, T: Deserial>(
 
 /// Write a Map as a list of key-value pairs ordered by the key, without the
 /// length information.
-pub fn serial_map_no_length<'a, W: Write, K: Serial + 'a, V: Serial + 'a>(
+pub fn serial_map_no_length<W: Write, K: Serial, V: Serial>(
     map: &BTreeMap<K, V>,
     out: &mut W,
 ) -> Result<(), W::Err> {
@@ -471,7 +471,7 @@ pub fn deserial_map_no_length_no_order_check<R: Read, K: Deserial + Ord, V: Dese
 
 /// Write a HashMap as a list of key-value pairs in to particular order, without
 /// the length information.
-pub fn serial_hashmap_no_length<'a, W: Write, K: Serial + 'a, V: Serial + 'a>(
+pub fn serial_hashmap_no_length<W: Write, K: Serial, V: Serial>(
     map: &HashMap<K, V>,
     out: &mut W,
 ) -> Result<(), W::Err> {
@@ -499,7 +499,7 @@ pub fn deserial_hashmap_no_length<R: Read, K: Deserial + Eq + Hash, V: Deserial>
 }
 
 /// Write a [BTreeSet](https://doc.rust-lang.org/std/collections/struct.BTreeSet.html) as an ascending list of keys, without the length information.
-pub fn serial_set_no_length<'a, W: Write, K: Serial + 'a>(
+pub fn serial_set_no_length<W: Write, K: Serial>(
     map: &BTreeSet<K>,
     out: &mut W,
 ) -> Result<(), W::Err> {
@@ -531,7 +531,7 @@ pub fn deserial_set_no_length<R: Read, K: Deserial + Ord + Copy>(
 }
 
 /// Write a [HashSet](https://doc.rust-lang.org/std/collections/struct.HashSet.html) as a list of keys in no particular order, without the length information.
-pub fn serial_hashset_no_length<'a, W: Write, K: Serial + 'a>(
+pub fn serial_hashset_no_length<W: Write, K: Serial>(
     map: &HashSet<K>,
     out: &mut W,
 ) -> Result<(), W::Err> {
@@ -605,7 +605,7 @@ impl<K: Serial + Ord, V: Serial> Serial for BTreeMap<K, V> {
     }
 }
 
-/// The deserialization of maps assumes their size as a u32.
+/// The deserialization of maps assumes their size is a u32.
 ///
 /// <b style="color: darkred">WARNING</b>: Deserialization **does not** ensure
 /// the ordering of the keys, it only ensures that there are no duplicates.
@@ -634,7 +634,7 @@ impl<K: Serial, V: Serial> Serial for HashMap<K, V> {
     }
 }
 
-/// The deserialization of maps assumes their size as a u32.
+/// The deserialization of maps assumes their size is a u32.
 ///
 /// <b style="color: darkred">WARNING</b>: Deserialization only ensures that
 /// there are no duplicates. Serializing a `HashMap` via its `Serial` instance
@@ -660,7 +660,7 @@ impl<K: Serial + Ord> Serial for BTreeSet<K> {
     }
 }
 
-/// The deserialization of sets assumes their size as a u32.
+/// The deserialization of sets assumes their size is a u32.
 ///
 /// <b style="color: darkred">WARNING</b>: Deserialization **does not** ensure
 /// the ordering of the keys, it only ensures that there are no duplicates.
@@ -689,7 +689,7 @@ impl<K: Serial> Serial for HashSet<K> {
     }
 }
 
-/// The deserialization of sets assumes their size as a u32.
+/// The deserialization of sets assumes their size is a u32.
 ///
 /// <b style="color: darkred">WARNING</b>: Deserialization only ensures that
 /// there are no duplicates. Serializing a `HashSet` via its `Serial` instance

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -181,8 +181,8 @@ impl SchemaType for ContractAddress {
 impl SchemaType for Address {
     fn get_type() -> Type {
         Type::Enum(Vec::from([
-            (String::from("account"), Fields::Unnamed(Vec::from([Type::AccountAddress]))),
-            (String::from("contract"), Fields::Unnamed(Vec::from([Type::ContractAddress]))),
+            (String::from("Account"), Fields::Unnamed(Vec::from([Type::AccountAddress]))),
+            (String::from("Contract"), Fields::Unnamed(Vec::from([Type::ContractAddress]))),
         ]))
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -176,6 +176,14 @@ impl SchemaType for AccountAddress {
 impl SchemaType for ContractAddress {
     fn get_type() -> Type { Type::ContractAddress }
 }
+impl SchemaType for Address {
+    fn get_type() -> Type {
+        Type::Enum(Vec::from([
+            (String::from("account"), Fields::Unnamed(Vec::from([Type::AccountAddress]))),
+            (String::from("contract"), Fields::Unnamed(Vec::from([Type::ContractAddress]))),
+        ]))
+    }
+}
 impl SchemaType for Timestamp {
     fn get_type() -> Type { Type::Timestamp }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -7,7 +7,7 @@ use crate::{impls::*, traits::*, types::*};
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 #[cfg(not(feature = "std"))]
-use alloc::{collections::*, string::String, vec::Vec};
+use alloc::{collections, string::String, vec::Vec};
 #[cfg(not(feature = "std"))]
 use core::{
     convert::{TryFrom, TryInto},
@@ -16,10 +16,12 @@ use core::{
 /// Contract schema related types
 #[cfg(feature = "std")]
 use std::{
-    collections::*,
+    collections,
     convert::{TryFrom, TryInto},
     num::TryFromIntError,
 };
+
+use collections::{BTreeMap, BTreeSet};
 
 /// The `SchemaType` trait provides means to generate a schema for structures.
 /// Schemas are used to make structures human readable and to avoid dealing
@@ -208,6 +210,14 @@ impl<T: SchemaType> SchemaType for BTreeSet<T> {
     fn get_type() -> Type { Type::Set(SizeLength::U32, Box::new(T::get_type())) }
 }
 impl<K: SchemaType, V: SchemaType> SchemaType for BTreeMap<K, V> {
+    fn get_type() -> Type {
+        Type::Map(SizeLength::U32, Box::new(K::get_type()), Box::new(V::get_type()))
+    }
+}
+impl<T: SchemaType> SchemaType for HashSet<T> {
+    fn get_type() -> Type { Type::Set(SizeLength::U32, Box::new(T::get_type())) }
+}
+impl<K: SchemaType, V: SchemaType> SchemaType for HashMap<K, V> {
     fn get_type() -> Type {
         Type::Map(SizeLength::U32, Box::new(K::get_type()), Box::new(V::get_type()))
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -8,6 +8,7 @@ use crate::{impls::*, traits::*, types::*};
 use alloc::boxed::Box;
 #[cfg(not(feature = "std"))]
 use alloc::{collections, string::String, vec::Vec};
+use collections::{BTreeMap, BTreeSet};
 #[cfg(not(feature = "std"))]
 use core::{
     convert::{TryFrom, TryInto},
@@ -20,8 +21,6 @@ use std::{
     convert::{TryFrom, TryInto},
     num::TryFromIntError,
 };
-
-use collections::{BTreeMap, BTreeSet};
 
 /// The `SchemaType` trait provides means to generate a schema for structures.
 /// Schemas are used to make structures human readable and to avoid dealing

--- a/src/types.rs
+++ b/src/types.rs
@@ -585,7 +585,7 @@ impl convert::AsRef<[u8]> for AccountAddress {
 }
 
 /// Address of a contract.
-#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+#[derive(Eq, PartialEq, Copy, Clone, Debug, PartialOrd, Ord)]
 #[cfg_attr(feature = "derive-serde", derive(SerdeSerialize, SerdeDeserialize))]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct ContractAddress {
@@ -600,7 +600,7 @@ pub struct ContractAddress {
     serde(tag = "type", content = "address", rename_all = "lowercase")
 )]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
-#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, PartialOrd, Ord, Debug)]
 pub enum Address {
     Account(AccountAddress),
     Contract(ContractAddress),

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,9 +2,19 @@ use crate::constants;
 #[cfg(not(feature = "std"))]
 use alloc::{string::String, string::ToString, vec::Vec};
 #[cfg(not(feature = "std"))]
-use core::{convert, fmt, iter, ops, str};
+use core::{convert, fmt, hash, iter, ops, str};
 #[cfg(feature = "std")]
-use std::{convert, fmt, iter, ops, str};
+use std::{convert, fmt, hash, iter, ops, str};
+
+use hash::Hash;
+
+/// Reexport of the `HashMap` from `hashbrown` with the default hasher set to
+/// the `fnv` hash function.
+pub type HashMap<K, V, S = fnv::FnvBuildHasher> = hashbrown::HashMap<K, V, S>;
+
+/// Reexport of the `HashSet` from `hashbrown` with the default hasher set to
+/// the `fnv` hash function.
+pub type HashSet<K, S = fnv::FnvBuildHasher> = hashbrown::HashSet<K, S>;
 
 #[cfg(feature = "fuzz")]
 use arbitrary::Arbitrary;
@@ -17,7 +27,7 @@ pub const ACCOUNT_ADDRESS_SIZE: usize = 32;
 
 /// The type of amounts on the chain
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct Amount {
     pub micro_gtu: u64,
@@ -310,7 +320,7 @@ impl ops::RemAssign<u64> for Amount {
 ///
 /// Timestamps from before January 1st 1970 at 00:00 are not supported.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct Timestamp {
     /// Milliseconds since unix epoch.
@@ -436,7 +446,7 @@ impl<'de> SerdeDeserialize<'de> for Timestamp {
 ///
 /// Negative durations are not allowed.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Duration {
     pub(crate) milliseconds: u64,
 }
@@ -572,7 +582,7 @@ impl fmt::Display for Duration {
 }
 
 /// Address of an account, as raw bytes.
-#[derive(Eq, PartialEq, Copy, Clone, PartialOrd, Ord, Debug)]
+#[derive(Eq, PartialEq, Copy, Clone, PartialOrd, Ord, Debug, Hash)]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct AccountAddress(pub [u8; ACCOUNT_ADDRESS_SIZE]);
 
@@ -585,7 +595,7 @@ impl convert::AsRef<[u8]> for AccountAddress {
 }
 
 /// Address of a contract.
-#[derive(Eq, PartialEq, Copy, Clone, Debug, PartialOrd, Ord)]
+#[derive(Eq, PartialEq, Copy, Clone, Debug, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "derive-serde", derive(SerdeSerialize, SerdeDeserialize))]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct ContractAddress {
@@ -600,14 +610,14 @@ pub struct ContractAddress {
     serde(tag = "type", content = "address", rename_all = "lowercase")
 )]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
-#[derive(PartialEq, Eq, Copy, Clone, PartialOrd, Ord, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, PartialOrd, Ord, Debug, Hash)]
 pub enum Address {
     Account(AccountAddress),
     Contract(ContractAddress),
 }
 
 /// A contract name. Expected format: "init_<contract_name>".
-#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+#[derive(Eq, PartialEq, Copy, Clone, Debug, Hash)]
 pub struct ContractName<'a>(&'a str);
 
 impl<'a> ContractName<'a> {
@@ -654,7 +664,7 @@ impl<'a> ContractName<'a> {
 }
 
 /// A contract name (owned version). Expected format: "init_<contract_name>".
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Hash)]
 pub struct OwnedContractName(String);
 
 impl OwnedContractName {
@@ -710,7 +720,7 @@ impl fmt::Display for NewContractNameError {
 }
 
 /// A receive name. Expected format: "<contract_name>.<func_name>".
-#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+#[derive(Eq, PartialEq, Copy, Clone, Debug, Hash)]
 pub struct ReceiveName<'a>(&'a str);
 
 impl<'a> ReceiveName<'a> {
@@ -755,7 +765,7 @@ impl<'a> ReceiveName<'a> {
 
 /// A receive name (owned version). Expected format:
 /// "<contract_name>.<func_name>".
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct OwnedReceiveName(String);
 
 impl OwnedReceiveName {

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,10 +3,9 @@ use crate::constants;
 use alloc::{string::String, string::ToString, vec::Vec};
 #[cfg(not(feature = "std"))]
 use core::{convert, fmt, hash, iter, ops, str};
+use hash::Hash;
 #[cfg(feature = "std")]
 use std::{convert, fmt, hash, iter, ops, str};
-
-use hash::Hash;
 
 /// Reexport of the `HashMap` from `hashbrown` with the default hasher set to
 /// the `fnv` hash function.

--- a/src/types.rs
+++ b/src/types.rs
@@ -615,7 +615,7 @@ pub enum Address {
     Contract(ContractAddress),
 }
 
-// This trait is implemented manually to save bytes
+// This trait is implemented manually to produce fewer bytes in the generated WASM.
 impl PartialEq for Address {
     fn eq(&self, other: &Address) -> bool {
         match (self, other) {
@@ -626,7 +626,7 @@ impl PartialEq for Address {
     }
 }
 
-// This trait is implemented manually to save bytes
+// This trait is implemented manually to produce fewer bytes in the generated WASM.
 impl Hash for Address {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         match self {
@@ -642,12 +642,12 @@ impl Hash for Address {
     }
 }
 
-// This trait is implemented manually to save bytes
+// This trait is implemented manually to produce fewer bytes in the generated WASM.
 impl PartialOrd for Address {
     fn partial_cmp(&self, other: &Address) -> Option<Ordering> { Some(self.cmp(other)) }
 }
 
-// This trait is implemented manually to save bytes
+// This trait is implemented manually to produce fewer bytes in the generated WASM.
 impl Ord for Address {
     fn cmp(&self, other: &Address) -> Ordering {
         match (self, other) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -615,7 +615,8 @@ pub enum Address {
     Contract(ContractAddress),
 }
 
-// This trait is implemented manually to produce fewer bytes in the generated WASM.
+// This trait is implemented manually to produce fewer bytes in the generated
+// WASM.
 impl PartialEq for Address {
     fn eq(&self, other: &Address) -> bool {
         match (self, other) {
@@ -626,7 +627,8 @@ impl PartialEq for Address {
     }
 }
 
-// This trait is implemented manually to produce fewer bytes in the generated WASM.
+// This trait is implemented manually to produce fewer bytes in the generated
+// WASM.
 impl Hash for Address {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         match self {
@@ -642,12 +644,14 @@ impl Hash for Address {
     }
 }
 
-// This trait is implemented manually to produce fewer bytes in the generated WASM.
+// This trait is implemented manually to produce fewer bytes in the generated
+// WASM.
 impl PartialOrd for Address {
     fn partial_cmp(&self, other: &Address) -> Option<Ordering> { Some(self.cmp(other)) }
 }
 
-// This trait is implemented manually to produce fewer bytes in the generated WASM.
+// This trait is implemented manually to produce fewer bytes in the generated
+// WASM.
 impl Ord for Address {
     fn cmp(&self, other: &Address) -> Ordering {
         match (self, other) {


### PR DESCRIPTION
## Purpose

Support using `Address` in a `BTreeMap` and contract schemas.
Types implement Hash and add support for hashmaps in `no-std`.

## Changes

- Derive `PartialOrd` and `Ord` for `ContractAddress` and `Address`.
- Implement `SchemaType` for `Address`.
- Add `HashMap` and `HashSet` from the `hashbrown` crate to support `no-std`.
- Make `HashMap` and `HashSet` default to the `fnv` hasher.
- Derive `Hash` for `Amount`, `Timestamp`, `Duration`, `AccountAddress`, `ContractAddress`, `Address`, `ContractName`, `OwnedContractName`, `ReceiveName` and `OwnedReceiveName`.


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

