### PR TITLE
Add derive Debug for the Address type

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -599,8 +599,8 @@ pub struct ContractAddress {
     derive(SerdeSerialize, SerdeDeserialize),
     serde(tag = "type", content = "address", rename_all = "lowercase")
 )]
-#[cfg_attr(feature = "fuzz", derive(Arbitrary, Debug))]
-#[derive(PartialEq, Eq, Copy, Clone)]
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum Address {
     Account(AccountAddress),
     Contract(ContractAddress),


### PR DESCRIPTION
## Purpose

Derive a `Debug` implementation for the `Address` type. It seems reasonable to have in all cases, not only for the "fuzz" feature, and it's consistent with the current `derive` for `ContractAddress` and `AccountAddress`.

## Changes

Added `Debug` to the list of derived trait implementations. Since it's derived unconditionally, we can remove it from the list for the "fuzz" feature.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
