### PR TITLE
Update rust to 1.53.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.45.2
+          toolchain: 1.53
           target: ${{ matrix.target }}
           override: true
           components: clippy
@@ -82,7 +82,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.45.2
+          toolchain: 1.53
           override: true
 
       - name: Run cargo test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased changes
 - Add public validation functions to contract and receive names
 - Add new cases for NewContractNameError and NewReceiveNameError
+- Remove the needless reference in `to_owned` and `get_chain_name` methods.
 
 ## concordium-contracts-common 0.4.0 (2021-05-12)
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -626,7 +626,7 @@ impl<'a> ContractName<'a> {
 
     /// Get contract name used on chain: "init_<contract_name>".
     #[inline(always)]
-    pub fn get_chain_name(&self) -> &str { self.0 }
+    pub fn get_chain_name(self) -> &'a str { self.0 }
 
     /// Check whether the given string is a valid contract initialization
     /// function name. This is the case if and only if
@@ -726,11 +726,11 @@ impl<'a> ReceiveName<'a> {
     pub fn new_unchecked(name: &'a str) -> Self { ReceiveName(name) }
 
     /// Get receive name used on chain: "<contract_name>.<func_name>".
-    pub fn get_chain_name(&self) -> &str { self.0 }
+    pub fn get_chain_name(self) -> &'a str { self.0 }
 
     /// Convert a `ReceiveName` to its owned counterpart. This is an expensive
     /// operation that requires memory allocation.
-    pub fn to_owned(&self) -> OwnedReceiveName { OwnedReceiveName(self.0.to_string()) }
+    pub fn to_owned(self) -> OwnedReceiveName { OwnedReceiveName(self.0.to_string()) }
 
     /// Check whether the given string is a valid contract receive function
     /// name. This is the case if and only if


### PR DESCRIPTION
As part of new clippy lints an inefficiency in the way receive and contract names
were handled was discovered. Changing the type of the methods is technically a
breaking API change. However since these are methods on a type that is Copy, the
impact is going to be negligible. Hence the decision to remove the needless indirection.

## Purpose

Support rust 1.53.

## Changes

- Remove the needless reference in `to_owned` and `get_chain_name` methods.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
