### PR TITLE
Add inline annotations to reduce generated code size.

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -213,6 +213,7 @@ impl<T: Serial> Serial for Box<T> {
 }
 
 impl<T: Deserial> Deserial for Box<T> {
+    #[inline]
     fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
         let t = T::deserial(source)?;
         Ok(Box::new(t))
@@ -220,10 +221,12 @@ impl<T: Deserial> Deserial for Box<T> {
 }
 
 impl<C: ?Sized> Serial for marker::PhantomData<C> {
+    #[inline(always)]
     fn serial<W: Write>(&self, _out: &mut W) -> Result<(), W::Err> { Ok(()) }
 }
 
 impl<C: ?Sized> Deserial for marker::PhantomData<C> {
+    #[inline(always)]
     fn deserial<R: Read>(_source: &mut R) -> ParseResult<Self> {
         Ok(marker::PhantomData::default())
     }
@@ -288,6 +291,7 @@ impl Serial for ContractAddress {
 }
 
 impl Deserial for ContractAddress {
+    #[inline]
     fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
         let index = source.get()?;
         let subindex = source.get()?;
@@ -789,6 +793,7 @@ pub fn to_bytes<S: Serial>(x: &S) -> Vec<u8> {
 }
 
 /// Dual to `to_bytes`.
+#[inline]
 pub fn from_bytes<S: Deserial>(source: &[u8]) -> ParseResult<S> {
     let mut cursor = Cursor::new(source);
     cursor.get()


### PR DESCRIPTION
## Purpose

Reduce code size. On a trivial contract example that only checks that the sender is an account this reduces code size from 9.7kB to 500B. The reason is that the allocator is not included when these functions are inlined.

## Changes

Add some inline annotations.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
