### PR TITLE
Use const generics for impl Serial and Deserial for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Make `HashMap` and `HashSet` default to the `fnv` hasher.
 - Add functions for serializing and deserializing `HashMap` and `HashSet` without the length (`serial_hashmap_no_length`, `deserial_hashmap_no_length`, `deserial_hashset_no_length`, `deserial_hashset_no_length`).
 - Use const generics in Serial, Deserial and SchemaType implementation for arrays.
+- Bump minimum supported Rust version to 1.51.
+
 ## concordium-contracts-common 0.4.0 (2021-05-12)
 
 - Add String to the schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add `HashMap` and `HashSet` from the `hashbrown` crate to support `no-std`.
 - Make `HashMap` and `HashSet` default to the `fnv` hasher.
 - Add functions for serializing and deserializing `HashMap` and `HashSet` without the length (`serial_hashmap_no_length`, `deserial_hashmap_no_length`, `deserial_hashset_no_length`, `deserial_hashset_no_length`).
+- Use const generics in Serial, Deserial and SchemaType implementation for arrays.
 ## concordium-contracts-common 0.4.0 (2021-05-12)
 
 - Add String to the schema.

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -9,17 +9,6 @@ use hash::Hash;
 #[cfg(feature = "std")]
 use std::{collections, hash, marker, mem::MaybeUninit, slice};
 
-/// Apply the given macro to each of the elements in the list
-/// For example, `repeat_macro!(println, "foo", "bar")` is equivalent to
-/// `println!("foo"); println!("bar").
-macro_rules! repeat_macro {
-    ($f:ident, $n:expr) => ($f!($n););
-    ($f:ident, $n:expr, $($ns:expr),*) => {
-        $f!($n);
-        repeat_macro!($f, $($ns),*);
-    };
-}
-
 // Implementations of Serialize
 
 impl<X: Serial, Y: Serial> Serial for (X, Y) {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -237,49 +237,9 @@ impl SchemaType for OwnedReceiveName {
     fn get_type() -> Type { Type::ReceiveName(SizeLength::U16) }
 }
 
-macro_rules! schema_type_array_x {
-    ($x:expr) => {
-        impl<A: SchemaType> SchemaType for [A; $x] {
-            fn get_type() -> Type { Type::Array($x, Box::new(A::get_type())) }
-        }
-    };
+impl<A: SchemaType, const N: usize> SchemaType for [A; N] {
+    fn get_type() -> Type { Type::Array(N.try_into().unwrap(), Box::new(A::get_type())) }
 }
-
-repeat_macro!(
-    schema_type_array_x,
-    1,
-    2,
-    3,
-    4,
-    5,
-    6,
-    7,
-    8,
-    9,
-    10,
-    11,
-    12,
-    13,
-    14,
-    15,
-    16,
-    17,
-    18,
-    19,
-    20,
-    21,
-    22,
-    23,
-    24,
-    25,
-    26,
-    27,
-    28,
-    29,
-    30,
-    31,
-    32
-);
 
 impl Serial for Fields {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {


### PR DESCRIPTION
## Purpose

Avoid macro generated implementations for array by using const generics.
 
## Changes

- Replace macro generated implementations up to 32 of Serial and Deserial for `[T, x]` with one using const generics.
- Replace macro generated implementations up to 32 of SchemaType for `[T, x]` with one using const generics.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
