### PR TITLE
Rename references to GTU to CCD.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased changes
+- Update references to token to match token name (CCD).
 
 ## concordium-contracts-common 1.0.1 (2021-10-08)
 - Fix deserialization of arrays.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-contracts-common"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -144,12 +144,12 @@ impl Deserial for bool {
 }
 
 impl Serial for Amount {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { out.write_u64(self.micro_gtu) }
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { out.write_u64(self.micro_ccd) }
 }
 
 impl Deserial for Amount {
     fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
-        source.read_u64().map(Amount::from_micro_gtu)
+        source.read_u64().map(Amount::from_micro_ccd)
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -646,7 +646,7 @@ mod impls {
                 }
                 Type::Amount => {
                     let n = Amount::deserial(source)?;
-                    Ok(Value::String(n.micro_gtu.to_string()))
+                    Ok(Value::String(n.micro_ccd.to_string()))
                 }
                 Type::AccountAddress => {
                     let address = AccountAddress::deserial(source)?;


### PR DESCRIPTION
## Purpose

As title states, this serves to update references to the token to match the token name.

## Changes

- Rename occurrences of GTU to CCD
- Bump major version due to changes to public API 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
