### PR TITLE
Introduce types for parameters and entrypoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Introduce Entrypoint and Parameter types, and their owned versions.
+
 ## concordium-contracts-common 2.0.0 (2022-01-05)
 
 - Update references to token to match token name (CCD).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased changes
+
+## concordium-contracts-common 2.0.0 (2022-01-05)
+
 - Update references to token to match token name (CCD).
 
 ## concordium-contracts-common 1.0.1 (2021-10-08)

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -366,6 +366,40 @@ impl Deserial for OwnedReceiveName {
     }
 }
 
+impl Serial for OwnedEntrypointName {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        let len = self.0.len() as u16;
+        len.serial(out)?;
+        serial_vector_no_length(self.0.as_bytes(), out)
+    }
+}
+
+impl Deserial for OwnedEntrypointName {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        let len: u16 = source.get()?;
+        let bytes = deserial_vector_no_length(source, len as usize)?;
+        let name = String::from_utf8(bytes).map_err(|_| ParseError::default())?;
+        let owned_entrypoint_name = Self::new(name).map_err(|_| ParseError::default())?;
+        Ok(owned_entrypoint_name)
+    }
+}
+
+impl Serial for OwnedParameter {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        let len = self.0.len() as u16;
+        len.serial(out)?;
+        out.write_all(&self.0)
+    }
+}
+
+impl Deserial for OwnedParameter {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        let len: u16 = source.get()?;
+        let bytes = deserial_vector_no_length(source, len as usize)?;
+        Ok(Self(bytes))
+    }
+}
+
 impl Serial for ChainMetadata {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.slot_time.serial(out) }
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -366,11 +366,17 @@ impl Deserial for OwnedReceiveName {
     }
 }
 
-impl Serial for OwnedEntrypointName {
+impl<'a> Serial for EntrypointName<'a> {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
         let len = self.0.len() as u16;
         len.serial(out)?;
         serial_vector_no_length(self.0.as_bytes(), out)
+    }
+}
+
+impl Serial for OwnedEntrypointName {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        self.as_entrypoint_name().serial(out)
     }
 }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -390,11 +390,17 @@ impl Deserial for OwnedEntrypointName {
     }
 }
 
-impl Serial for OwnedParameter {
+impl<'a> Serial for Parameter<'a> {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
         let len = self.0.len() as u16;
         len.serial(out)?;
         out.write_all(&self.0)
+    }
+}
+
+impl Serial for OwnedParameter {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        self.as_parameter().serial(out)
     }
 }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -26,6 +26,16 @@ impl<X: Deserial, Y: Deserial> Deserial for (X, Y) {
     }
 }
 
+impl Serial for () {
+    #[inline(always)]
+    fn serial<W: Write>(&self, _out: &mut W) -> Result<(), W::Err> { Ok(()) }
+}
+
+impl Deserial for () {
+    #[inline(always)]
+    fn deserial<R: Read>(_source: &mut R) -> ParseResult<Self> { Ok(()) }
+}
+
 impl Serial for u8 {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { out.write_u8(*self) }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -863,6 +863,15 @@ impl<'a> EntrypointName<'a> {
         is_valid_entrypoint_name(name)?;
         Ok(Self(name))
     }
+
+    /// Create a new name. **This does not check the format and is therefore
+    /// unsafe.** It is provided for convenience since sometimes it is
+    /// statically clear that the format is satisfied.
+    pub fn new_unchecked(name: &'a str) -> Self { Self(name) }
+}
+
+impl<'a> From<EntrypointName<'a>> for &'a str {
+    fn from(en: EntrypointName<'a>) -> Self { en.0 }
 }
 
 impl<'a> From<EntrypointName<'a>> for OwnedEntrypointName {
@@ -872,7 +881,11 @@ impl<'a> From<EntrypointName<'a>> for OwnedEntrypointName {
 /// An entrypoint name (owned version). Expected format:
 /// "<func_name>" where
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
-pub struct OwnedEntrypointName(pub String);
+pub struct OwnedEntrypointName(pub(crate) String);
+
+impl From<OwnedEntrypointName> for String {
+    fn from(oen: OwnedEntrypointName) -> Self { oen.0 }
+}
 
 impl OwnedEntrypointName {
     /// Create a new name and check the format. See [is_valid_entrypoint_name]
@@ -881,6 +894,11 @@ impl OwnedEntrypointName {
         is_valid_entrypoint_name(&name)?;
         Ok(Self(name))
     }
+
+    /// Create a new name. **This does not check the format and is therefore
+    /// unsafe.** It is provided for convenience since sometimes it is
+    /// statically clear that the format is satisfied.
+    pub fn new_unchecked(name: String) -> Self { Self(name) }
 
     pub fn as_entrypoint_name(&self) -> EntrypointName { EntrypointName(self.0.as_str()) }
 }
@@ -904,7 +922,7 @@ impl OwnedParameter {
 ///
 /// [m]: ./constants/constant.MAX_FUNC_NAME_SIZE.html
 pub fn is_valid_entrypoint_name(name: &str) -> Result<(), NewReceiveNameError> {
-    if name.len() > constants::MAX_FUNC_NAME_SIZE {
+    if name.as_bytes().len() > constants::MAX_FUNC_NAME_SIZE {
         return Err(NewReceiveNameError::TooLong);
     }
     if !name.chars().all(|c| c.is_ascii_alphanumeric() || c.is_ascii_punctuation()) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -848,6 +848,40 @@ impl OwnedReceiveName {
     pub fn as_ref(&self) -> ReceiveName { ReceiveName(self.0.as_str()) }
 }
 
+/// An entrypoint name (owned version). Expected format:
+/// "<func_name>" where
+#[derive(Eq, PartialEq, Debug, Clone, Hash)]
+pub struct OwnedEntrypointName(pub String);
+
+impl OwnedEntrypointName {
+    /// Create a new name and check the format. See [is_valid_entrypoint_name]
+    /// for the expected format.
+    pub fn new(name: String) -> Result<Self, NewReceiveNameError> {
+        is_valid_entrypoint_name(&name)?;
+        Ok(Self(name))
+    }
+}
+
+/// Parameter to the init function or entrypoint.
+#[derive(Eq, PartialEq, Debug, Clone, Hash)]
+pub struct OwnedParameter(pub Vec<u8>);
+
+/// Check whether the given string is a valid contract entrypoint name.
+/// This is the case if and only if
+/// - the string is no more than [constants::MAX_FUNC_NAME_SIZE][m] bytes
+/// - all characters are ascii alphanumeric or punctuation characters.
+///
+/// [m]: ./constants/constant.MAX_FUNC_NAME_SIZE.html
+pub fn is_valid_entrypoint_name(name: &str) -> Result<(), NewReceiveNameError> {
+    if name.len() > constants::MAX_FUNC_NAME_SIZE {
+        return Err(NewReceiveNameError::TooLong);
+    }
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c.is_ascii_punctuation()) {
+        return Err(NewReceiveNameError::InvalidCharacters);
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NewReceiveNameError {
     MissingDotSeparator,
@@ -882,7 +916,8 @@ pub type SlotTime = Timestamp;
     derive(SerdeSerialize, SerdeDeserialize),
     serde(rename_all = "camelCase")
 )]
-#[cfg_attr(feature = "fuzz", derive(Arbitrary, Debug, Clone))]
+#[cfg_attr(feature = "fuzz", derive(Arbitrary, Clone))]
+#[derive(Debug)]
 pub struct ChainMetadata {
     pub slot_time: SlotTime,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -870,6 +870,10 @@ impl<'a> EntrypointName<'a> {
     pub fn new_unchecked(name: &'a str) -> Self { Self(name) }
 }
 
+impl<'a> fmt::Display for EntrypointName<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str(self.0) }
+}
+
 impl<'a> From<EntrypointName<'a>> for &'a str {
     fn from(en: EntrypointName<'a>) -> Self { en.0 }
 }
@@ -882,6 +886,10 @@ impl<'a> From<EntrypointName<'a>> for OwnedEntrypointName {
 /// "<func_name>" where
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct OwnedEntrypointName(pub(crate) String);
+
+impl fmt::Display for OwnedEntrypointName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.as_entrypoint_name().fmt(f) }
+}
 
 impl From<OwnedEntrypointName> for String {
     fn from(oen: OwnedEntrypointName) -> Self { oen.0 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -848,6 +848,24 @@ impl OwnedReceiveName {
     pub fn as_ref(&self) -> ReceiveName { ReceiveName(self.0.as_str()) }
 }
 
+/// An entrypoint name (borrowed version). Expected format:
+/// "<func_name>" where
+#[derive(Eq, PartialEq, Debug, Clone, Copy, Hash)]
+pub struct EntrypointName<'a>(pub(crate) &'a str);
+
+impl<'a> EntrypointName<'a> {
+    /// Create a new name and check the format. See [is_valid_entrypoint_name]
+    /// for the expected format.
+    pub fn new(name: &'a str) -> Result<Self, NewReceiveNameError> {
+        is_valid_entrypoint_name(name)?;
+        Ok(Self(name))
+    }
+}
+
+impl<'a> From<EntrypointName<'a>> for OwnedEntrypointName {
+    fn from(epn: EntrypointName<'a>) -> Self { Self(String::from(epn.0)) }
+}
+
 /// An entrypoint name (owned version). Expected format:
 /// "<func_name>" where
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
@@ -860,6 +878,8 @@ impl OwnedEntrypointName {
         is_valid_entrypoint_name(&name)?;
         Ok(Self(name))
     }
+
+    pub fn as_entrypoint_name(&self) -> EntrypointName { EntrypointName(self.0.as_str()) }
 }
 
 /// Parameter to the init function or entrypoint.

--- a/src/types.rs
+++ b/src/types.rs
@@ -854,6 +854,9 @@ impl OwnedReceiveName {
 pub struct EntrypointName<'a>(pub(crate) &'a str);
 
 impl<'a> EntrypointName<'a> {
+    /// Size of the name in bytes.
+    pub fn size(&self) -> u32 { self.0.as_bytes().len() as u32 }
+
     /// Create a new name and check the format. See [is_valid_entrypoint_name]
     /// for the expected format.
     pub fn new(name: &'a str) -> Result<Self, NewReceiveNameError> {
@@ -883,8 +886,16 @@ impl OwnedEntrypointName {
 }
 
 /// Parameter to the init function or entrypoint.
+#[derive(Eq, PartialEq, Debug, Clone, Copy, Hash)]
+pub struct Parameter<'a>(pub &'a [u8]);
+
+/// Parameter to the init function or entrypoint. Owned version.
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct OwnedParameter(pub Vec<u8>);
+
+impl OwnedParameter {
+    pub fn as_parameter(&self) -> Parameter { Parameter(self.0.as_ref()) }
+}
 
 /// Check whether the given string is a valid contract entrypoint name.
 /// This is the case if and only if


### PR DESCRIPTION
## Purpose

Introduce types for parameters and entrypoints.

## Changes

Introduce new types for entrypoints and parameters. The latter is useful to have a central place for its serialization.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.