### PR TITLE
Auto-serializing constructor for `OwnedParameter`

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -934,6 +934,7 @@ impl<'a> AsRef<[u8]> for OwnedParameter {
     fn as_ref(&self) -> &[u8] { self.0.as_ref() }
 }
 
+/// Convert the vector into a parameter as is.
 impl From<Vec<u8>> for OwnedParameter {
     #[inline(always)]
     fn from(param: Vec<u8>) -> Self { Self(param) }
@@ -945,9 +946,6 @@ impl OwnedParameter {
     /// Construct an `OwnedParameter` by serializing the input using its
     /// `Serial` instance.
     pub fn new<D: Serial>(data: &D) -> Self { Self(to_bytes(data)) }
-
-    /// Construct an `OwnedParameter` from the raw, serialized, data.
-    pub fn new_raw(data: Vec<u8>) -> Self { Self(data) }
 }
 
 /// Check whether the given string is a valid contract entrypoint name.

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,4 @@
-use crate::constants;
+use crate::{constants, to_bytes, Serial};
 #[cfg(not(feature = "std"))]
 use alloc::{string::String, string::ToString, vec::Vec};
 #[cfg(feature = "fuzz")]
@@ -941,6 +941,13 @@ impl From<Vec<u8>> for OwnedParameter {
 
 impl OwnedParameter {
     pub fn as_parameter(&self) -> Parameter { Parameter(self.0.as_ref()) }
+
+    /// Construct an `OwnedParameter` by serializing the input using its
+    /// `Serial` instance.
+    pub fn new<D: Serial>(data: &D) -> Self { Self(to_bytes(data)) }
+
+    /// Construct an `OwnedParameter` from the raw, serialized, data.
+    pub fn new_raw(data: Vec<u8>) -> Self { Self(data) }
 }
 
 /// Check whether the given string is a valid contract entrypoint name.


### PR DESCRIPTION
## Purpose

Adds an auto-serializing constructor for `OwnedParameter` similar to what we had with the `send` helper function.

## Changes

Add two constructors to `OwnedParameter`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.