### PR TITLE
Add a few helper instances related to receive/entrypoint names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Introduce Entrypoint and Parameter types, and their owned versions.
 - Add a new schema version for V1 smart contracts. 
   This adds schema for return values of init and receive functions, and removes the state schema.
+- `get_chain_name`, `get_name_parts` have been moved from `OwnedReceiveName` to
+  `ReceiveName`. The method `get_func_name` of `OwnedReceiveName` became
+  `get_entrypoint_name` of `ReceiveName`.
 
 ## concordium-contracts-common 2.0.0 (2022-01-05)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-contracts-common"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -363,7 +363,9 @@ impl<'a> Serial for ReceiveName<'a> {
 }
 
 impl Serial for OwnedReceiveName {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.as_ref().serial(out) }
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        self.as_receive_name().serial(out)
+    }
 }
 
 impl Deserial for OwnedReceiveName {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -863,7 +863,6 @@ mod tests {
 
         let seed: u64 = random();
         let mut rng = Pcg64::seed_from_u64(seed);
-        println!("Seed {}", seed);
         let mut data = [0u8; 100000];
         rng.fill_bytes(&mut data);
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -838,11 +838,12 @@ mod impls {
                     Ok(json!({ "contract": name_without_init }))
                 }
                 Type::ReceiveName(size_len) => {
-                    let receive_name = OwnedReceiveName::new(deserial_string(source, *size_len)?)
-                        .map_err(|_| ParseError::default())?;
-                    let contract_name =
-                        receive_name.contract_name().ok_or_else(ParseError::default)?;
-                    let func_name = receive_name.func_name().ok_or_else(ParseError::default)?;
+                    let owned_receive_name =
+                        OwnedReceiveName::new(deserial_string(source, *size_len)?)
+                            .map_err(|_| ParseError::default())?;
+                    let receive_name = owned_receive_name.as_receive_name();
+                    let contract_name = receive_name.contract_name();
+                    let func_name = receive_name.entrypoint_name();
                     Ok(json!({"contract": contract_name, "func": func_name}))
                 }
             }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,26 +3,29 @@ use crate::types::*;
 use alloc::vec::Vec;
 use core::{default::Default, mem::MaybeUninit, slice};
 
-/// This is the equivalent to the
+/// This is essentially equivalent to the
 /// [SeekFrom](https://doc.rust-lang.org/std/io/enum.SeekFrom.html) type from
 /// the rust standard library, but reproduced here to avoid dependency on
-/// `std::io`.
+/// `std::io`, as well as to use 32-bit integers to specify positions. This
+/// saves some computation and space, and is adequate for the kind of data sizes
+/// that are possible in smart contracts.
 pub enum SeekFrom {
-    Start(u64),
-    End(i64),
-    Current(i64),
+    Start(u32),
+    End(i32),
+    Current(i32),
 }
 
 /// The `Seek` trait provides a cursor which can be moved within a stream of
 /// bytes. This is essentially a copy of
 /// [std::io::Seek](https://doc.rust-lang.org/std/io/trait.Seek.html), but
 /// avoiding its dependency on `std::io::Error`, and the associated code size
-/// increase.
+/// increase. Additionally, the positions are expressed in terms on 32-bit
+/// integers since this is adequate for the sizes of data in smart contracts.
 pub trait Seek {
     type Err;
     /// Seek to the new position. If successful, return the new position from
     /// the beginning of the stream.
-    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Err>;
+    fn seek(&mut self, pos: SeekFrom) -> Result<u32, Self::Err>;
 }
 
 /// Reads `n` bytes from a given `source` without initializing the byte array

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -111,6 +111,9 @@ pub trait Read {
         let bytes = read_n_bytes!(1, self);
         Ok(i8::from_le_bytes(bytes))
     }
+
+    /// Load an array of the given size.
+    fn read_array<const N: usize>(&mut self) -> ParseResult<[u8; N]> { Ok(read_n_bytes!(N, self)) }
 }
 
 /// The `Write` trait provides functionality for writing to byte streams.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -19,7 +19,7 @@ pub enum SeekFrom {
 /// bytes. This is essentially a copy of
 /// [std::io::Seek](https://doc.rust-lang.org/std/io/trait.Seek.html), but
 /// avoiding its dependency on `std::io::Error`, and the associated code size
-/// increase. Additionally, the positions are expressed in terms on 32-bit
+/// increase. Additionally, the positions are expressed in terms of 32-bit
 /// integers since this is adequate for the sizes of data in smart contracts.
 pub trait Seek {
     type Err;

--- a/src/types.rs
+++ b/src/types.rs
@@ -541,7 +541,7 @@ impl fmt::Display for ParseDurationError {
 ///
 /// # Example
 /// The duration of 10 days, 1 hour, 2minutes and 7 seconds is:
-/// ```ignore
+/// ```text
 /// "10d 1h 2m 3s 4s"
 /// ```
 impl str::FromStr for Duration {
@@ -1246,24 +1246,23 @@ pub mod attributes {
 /// or parameters.
 ///
 /// ```ignore
+/// # use concordium_std::*;
 /// enum MyCustomReceiveError {
 ///     Parsing
 /// }
 ///
 /// impl From<ParseError> for MyCustomReceiveError {
-///     fn from(_: ParseError) -> Self { MyCustomReceiveError::ParseParams }
+///     fn from(_: ParseError) -> Self { MyCustomReceiveError::Parsing }
 /// }
 ///
-/// #[receive(contract = "mycontract", name="some_receive_name")]
-/// fn contract_receive<R: HasReceiveContext, L: HasLogger, A: HasActions>(
-///     ctx: &R,
-///     receive_amount: Amount,
-///     logger: &mut L,
-///     state: &mut State,
+/// #[receive(contract = "mycontract", name="some_receive_name", mutable)]
+/// fn contract_receive<S: HasStateApi>(
+///     ctx: &impl HasReceiveContext,
+///     host: &mut impl HasHost<State, StateApiType = S>,
 /// ) -> Result<A, MyCustomReceiveError> {
-///     ...
+///     // ...
 ///     let msg: MyParameterType = ctx.parameter_cursor().get()?;
-///     ...
+///     // ...
 /// }
 /// ```
 #[derive(Debug, Default, PartialEq, Eq)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -855,6 +855,26 @@ impl OwnedReceiveName {
         Ok(OwnedReceiveName(name))
     }
 
+    /// Construct a receive name from contract and entrypoint names.
+    pub fn construct(
+        contract: ContractName,
+        entrypoint: EntrypointName,
+    ) -> Result<Self, NewReceiveNameError> {
+        let mut rm = contract.contract_name().to_string();
+        rm.push('.');
+        rm.push_str(entrypoint.0);
+        Self::new(rm)
+    }
+
+    /// Construct a receive name from contract and entrypoint names, assuming
+    /// that the resulting name is valid.
+    pub fn construct_unchecked(contract: ContractName, entrypoint: EntrypointName) -> Self {
+        let mut rm = contract.contract_name().to_string();
+        rm.push('.');
+        rm.push_str(entrypoint.0);
+        Self::new_unchecked(rm)
+    }
+
     /// Create a new OwnedReceiveName without checking the format. Expected
     /// format: "<contract_name>.<func_name>".
     #[inline(always)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -593,6 +593,13 @@ impl convert::AsRef<[u8]> for AccountAddress {
     fn as_ref(&self) -> &[u8] { &self.0 }
 }
 
+impl AccountAddress {
+    /// Check whether `self` is an alias of `other`. Two addresses are aliases
+    /// if they identify the same account. This is defined to be when the
+    /// addresses agree on the first 29 bytes.
+    pub fn is_alias(&self, other: &AccountAddress) -> bool { self.0[0..29] == other.0[0..29] }
+}
+
 /// Address of a contract.
 #[derive(Eq, PartialEq, Copy, Clone, Debug, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "derive-serde", derive(SerdeSerialize, SerdeDeserialize))]

--- a/src/types.rs
+++ b/src/types.rs
@@ -789,13 +789,13 @@ impl<'a> ReceiveName<'a> {
     /// operation that requires memory allocation.
     pub fn to_owned(self) -> OwnedReceiveName { OwnedReceiveName(self.0.to_string()) }
 
-    /// Try to extract the contract name by splitting at the first dot.
+    /// Extract the contract name by splitting at the first dot.
     pub fn contract_name(&self) -> &str { self.get_name_parts().0 }
 
-    /// Try to extract the func name by splitting at the first dot.
+    /// Extract the entrypoint name by splitting at the first dot.
     pub fn entrypoint_name(&self) -> EntrypointName { EntrypointName(self.get_name_parts().1) }
 
-    /// Try to extract (contract_name, func_name) by splitting at the first dot.
+    /// Extract (contract_name, func_name) by splitting at the first dot.
     fn get_name_parts(&self) -> (&str, &str) {
         let mut splitter = self.get_chain_name().splitn(2, '.');
         let contract = splitter.next().unwrap_or("");

--- a/src/types.rs
+++ b/src/types.rs
@@ -162,7 +162,7 @@ impl str::FromStr for Amount {
 impl Amount {
     /// Create amount from a number of microCCD
     #[inline(always)]
-    pub fn from_micro_ccd(micro_ccd: u64) -> Amount {
+    pub const fn from_micro_ccd(micro_ccd: u64) -> Amount {
         Amount {
             micro_ccd,
         }
@@ -170,7 +170,7 @@ impl Amount {
 
     /// Create amount from a number of CCD
     #[inline(always)]
-    pub fn from_ccd(ccd: u64) -> Amount {
+    pub const fn from_ccd(ccd: u64) -> Amount {
         Amount {
             micro_ccd: ccd * 1_000_000,
         }
@@ -178,7 +178,7 @@ impl Amount {
 
     /// Create zero amount
     #[inline(always)]
-    pub fn zero() -> Amount {
+    pub const fn zero() -> Amount {
         Amount {
             micro_ccd: 0,
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -768,6 +768,7 @@ impl fmt::Display for NewContractNameError {
 
 /// A receive name. Expected format: "<contract_name>.<func_name>".
 #[derive(Eq, PartialEq, Copy, Clone, Debug, Hash)]
+#[repr(transparent)]
 pub struct ReceiveName<'a>(&'a str);
 
 impl<'a> ReceiveName<'a> {
@@ -780,6 +781,7 @@ impl<'a> ReceiveName<'a> {
 
     /// Create a new ReceiveName without checking the format. Expected format:
     /// "<contract_name>.<func_name>".
+    #[inline(always)]
     pub fn new_unchecked(name: &'a str) -> Self { ReceiveName(name) }
 
     /// Get receive name used on chain: "<contract_name>.<func_name>".
@@ -790,13 +792,13 @@ impl<'a> ReceiveName<'a> {
     pub fn to_owned(self) -> OwnedReceiveName { OwnedReceiveName(self.0.to_string()) }
 
     /// Extract the contract name by splitting at the first dot.
-    pub fn contract_name(&self) -> &str { self.get_name_parts().0 }
+    pub fn contract_name(self) -> &'a str { self.get_name_parts().0 }
 
     /// Extract the entrypoint name by splitting at the first dot.
-    pub fn entrypoint_name(&self) -> EntrypointName { EntrypointName(self.get_name_parts().1) }
+    pub fn entrypoint_name(self) -> EntrypointName<'a> { EntrypointName(self.get_name_parts().1) }
 
     /// Extract (contract_name, func_name) by splitting at the first dot.
-    fn get_name_parts(&self) -> (&str, &str) {
+    fn get_name_parts(self) -> (&'a str, &'a str) {
         let mut splitter = self.get_chain_name().splitn(2, '.');
         let contract = splitter.next().unwrap_or("");
         let func = splitter.next().unwrap_or("");
@@ -825,7 +827,9 @@ impl<'a> ReceiveName<'a> {
 }
 
 /// A receive name (owned version). Expected format:
-/// "<contract_name>.<func_name>".
+/// "<contract_name>.<func_name>". Most methods are available only on the
+/// [`ReceiveName`] type, the intention is to access those via the
+/// [`as_receive_name`](OwnedReceiveName::as_receive_name) method.
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 #[cfg_attr(feature = "derive-serde", derive(SerdeSerialize, SerdeDeserialize))]
 #[cfg_attr(feature = "derive-serde", serde(try_from = "String"))]
@@ -834,6 +838,7 @@ pub struct OwnedReceiveName(String);
 impl convert::TryFrom<String> for OwnedReceiveName {
     type Error = NewReceiveNameError;
 
+    #[inline(always)]
     fn try_from(value: String) -> Result<Self, Self::Error> { OwnedReceiveName::new(value) }
 }
 
@@ -850,16 +855,19 @@ impl OwnedReceiveName {
     #[inline(always)]
     pub fn new_unchecked(name: String) -> Self { OwnedReceiveName(name) }
 
-    /// Convert to ReceiveName by reference.
+    /// Convert to [`ReceiveName`]. See [`ReceiveName`] for additional methods
+    /// available on the type.
     #[inline(always)]
     pub fn as_receive_name(&self) -> ReceiveName { ReceiveName(self.0.as_str()) }
 }
 
 /// An entrypoint name (borrowed version). Expected format:
-/// "<func_name>" where
+/// "<func_name>" where the name of the function consists solely of ASCII
+/// alphanumeric or punctuation characters.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Copy, Hash)]
 #[cfg_attr(feature = "derive-serde", derive(SerdeSerialize))]
 #[cfg_attr(feature = "derive-serde", serde(transparent))]
+#[repr(transparent)]
 pub struct EntrypointName<'a>(pub(crate) &'a str);
 
 impl<'a> EntrypointName<'a> {
@@ -876,6 +884,7 @@ impl<'a> EntrypointName<'a> {
     /// Create a new name. **This does not check the format and is therefore
     /// unsafe.** It is provided for convenience since sometimes it is
     /// statically clear that the format is satisfied.
+    #[inline(always)]
     pub fn new_unchecked(name: &'a str) -> Self { Self(name) }
 }
 
@@ -892,7 +901,9 @@ impl<'a> From<EntrypointName<'a>> for OwnedEntrypointName {
 }
 
 /// An entrypoint name (owned version). Expected format:
-/// "<func_name>" where
+/// "<func_name>". Most methods on this type are available via the
+/// [`as_entrypoint_name`](OwnedEntrypointName::as_entrypoint_name) and the
+/// methods on the [`EntrypointName`] type.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Hash)]
 #[cfg_attr(feature = "derive-serde", derive(SerdeSerialize, SerdeDeserialize))]
 #[cfg_attr(feature = "derive-serde", serde(into = "String", try_from = "String"))]
@@ -923,8 +934,10 @@ impl OwnedEntrypointName {
     /// Create a new name. **This does not check the format and is therefore
     /// unsafe.** It is provided for convenience since sometimes it is
     /// statically clear that the format is satisfied.
+    #[inline(always)]
     pub fn new_unchecked(name: String) -> Self { Self(name) }
 
+    #[inline(always)]
     pub fn as_entrypoint_name(&self) -> EntrypointName { EntrypointName(self.0.as_str()) }
 }
 


### PR DESCRIPTION
## Purpose

Minor helpers and instances that are needed in cargo-concordium.

## Changes

The main change is moving some methods from OwnedReceiveName to ReceiveName since they are sometimes needed there, and since it is cheap to convert to the latter from the former, 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.