### PR TITLE
Remove the intermediate vector allocation when serializing strings.

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -189,7 +189,10 @@ impl Deserial for Duration {
 /// utf8-encoding of the string, then writing the bytes. Similar to `Vec<_>`.
 impl Serial for &str {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        self.as_bytes().to_vec().serial(out)
+        let bytes = self.as_bytes();
+        let len = bytes.len() as u32;
+        len.serial(out)?;
+        out.write_all(bytes)
     }
 }
 


### PR DESCRIPTION

## Purpose

Closes #31.

## Changes

Directly serialize the byte array.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.