### PR TITLE
Add Leb128 integers and bytes to the contract schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased changes
 
-- Extend schema type with ULeb128, ILeb128, ByteList and ByteArray.
-- Add new schema module which include the versioning in the serialization.
-- Change SchemaType implementation for byte arrays.
+- Extend schema type with `ULeb128`, `ILeb128`, `ByteList` and `ByteArray`.
+- Add new schema version which include the versioning in the serialization.
+- Use `schema::Type::ByteList` for `[u8]` implementation of `SchemaType`.
 
 ## concordium-contracts-common 3.0.0 (2022-05-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+- Extend schema type with ULeb128, ILeb128, ByteList and ByteArray.
+- Add new schema module which include the versioning in the serialization.
+- Change SchemaType implementation for byte arrays.
+
 ## concordium-contracts-common 3.0.0 (2022-05-17)
 
 - Introduce Entrypoint and Parameter types, and their owned versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased changes
 
 - Extend schema type with `ULeb128`, `ILeb128`, `ByteList` and `ByteArray`.
+  - `ULeb128` and `ILeb128` allow for integers of arbitrary size and are represented in JSON as a string containing the integer.
+  - `ByteList` and `ByteArray` are byte specialized versions of `List` and `Array` and are represented in JSON as lowercase hex encoded strings.  
 - Add new schema version which include the versioning in the serialization.
 - Use `schema::Type::ByteList` for `[u8]` implementation of `SchemaType`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,12 +39,20 @@ version = "0.4.19"
 optional = true
 version = "0.1"
 
+[dependencies.num-bigint]
+optional = true
+version = "0.4"
+
+[dependencies.num-traits]
+optional = true
+version = "0.2"
+
 [features]
 default = ["std"]
 
 std = ["fnv/std"]
 
-derive-serde = ["serde", "serde_json", "std", "base58check", "chrono"]
+derive-serde = ["serde", "serde_json", "std", "base58check", "chrono", "num-bigint", "num-traits"]
 
 fuzz = ["derive-serde", "arbitrary"]
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -934,7 +934,8 @@ mod impls {
                 }
                 Type::ByteList(size_len) => {
                     let len = deserial_length(source, *size_len)?;
-                    let mut string = String::with_capacity(len);
+                    let mut string =
+                        String::with_capacity(std::cmp::min(MAX_PREALLOCATED_CAPACITY, 2 * len));
                     for _ in 0..len {
                         let byte = source.read_u8()?;
                         string.push_str(&format!("{:02x?}", byte));
@@ -943,7 +944,8 @@ mod impls {
                 }
                 Type::ByteArray(len) => {
                     let len = usize::try_from(*len)?;
-                    let mut string = String::with_capacity(len);
+                    let mut string =
+                        String::with_capacity(std::cmp::min(MAX_PREALLOCATED_CAPACITY, 2 * len));
                     for _ in 0..len {
                         let byte = source.read_u8()?;
                         string.push_str(&format!("{:02x?}", byte));

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -48,7 +48,7 @@ pub struct ModuleV1 {
 /// Contains all the contract schemas for a module newer than V1 module.
 #[derive(Debug, Clone)]
 pub enum VersionedModule {
-    /// Schema module version 0
+    /// Versioned schema module version 0
     V0(ModuleV1),
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -33,19 +33,30 @@ pub trait SchemaType {
     fn get_type() -> crate::schema::Type;
 }
 
-/// Contains all the contract schemas for a V0 module
+/// Contains all the contract schemas for a smart contract module V0.
+///
+/// When embedded into a smart contract module, name the custom section
+/// `concordium-schema-v1`.
 #[derive(Debug, Clone)]
 pub struct ModuleV0 {
     pub contracts: BTreeMap<String, ContractV0>,
 }
 
-/// Contains all the contract schemas for a V1 module
+/// Contains all the contract schemas for a smart contract module V1.
+///
+/// When embedded into a smart contract module, name the custom section
+/// `concordium-schema-v2`.
 #[derive(Debug, Clone)]
 pub struct ModuleV1 {
     pub contracts: BTreeMap<String, ContractV1>,
 }
 
-/// Represents every schema module starting from V1.
+/// Represents every schema module starting from smart contract module V1.
+///
+/// The serialization of this type includes the versioning information.
+///
+/// When embedded into a smart contract module, name the custom section
+/// `concordium-schema`.
 #[derive(Debug, Clone)]
 pub enum VersionedModuleSchema {
     V1(ModuleV1),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -54,8 +54,8 @@ pub struct ModuleV1 {
 /// Represents the different schema versions.
 ///
 /// The serialization of this type includes the versioning information. The
-/// serializtion of this is always prefixed with two 255u8 in order to
-/// distinquish this versioned schema from the unversioned.
+/// serialization of this is always prefixed with two 255u8 in order to
+/// distinguish this versioned schema from the unversioned.
 ///
 /// When embedded into a smart contract module, name the custom section
 /// `concordium-schema`.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -131,37 +131,72 @@ pub enum SizeLength {
     U64,
 }
 
-/// Schema type used to describe the different types in a rust smart
-/// contract.
+/// Schema type used to describe the different types in a smart contract, their
+/// serialization and how to represent the types in JSON.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 pub enum Type {
+    /// A type with no serialization.
     Unit,
+    /// Boolean. Serialized as a byte, where the value 0 is false and 1 is true.
     Bool,
+    /// Unsigned 8-bit integer.
     U8,
+    /// Unsigned 16-bit integer. Serialized as little endian.
     U16,
+    /// Unsigned 32-bit integer. Serialized as little endian.
     U32,
+    /// Unsigned 64-bit integer. Serialized as little endian.
     U64,
+    /// Unsigned 128-bit integer. Serialized as little endian.
     U128,
+    /// Signed 8-bit integer. Serialized as little endian.
     I8,
+    /// Signed 16-bit integer. Serialized as little endian.
     I16,
+    /// Signed 32-bit integer. Serialized as little endian.
     I32,
+    /// Signed 64-bit integer. Serialized as little endian.
     I64,
+    /// Signed 128-bit integer. Serialized as little endian.
     I128,
+    /// An amount of CCD. Serialized as 64-bit unsigned integer little endian.
     Amount,
+    /// An account address.
     AccountAddress,
+    /// A contract address.
     ContractAddress,
+    /// A timestamp. Represented as milliseconds since Unix epoch. Serialized as
+    /// a 64-bit unsigned integer little endian.
     Timestamp,
+    /// A duration of milliseconds, cannot be negative. Serialized as a 64-bit
+    /// unsigned integer little endian.
     Duration,
+    /// A pair.
     Pair(Box<Type>, Box<Type>),
+    /// A list. It is serialized with the length first followed by the list
+    /// items.
     List(SizeLength, Box<Type>),
+    /// A Set. It is serialized with the length first followed by the list
+    /// items.
     Set(SizeLength, Box<Type>),
+    /// A Map. It is serialized with the length first followed by key-value
+    /// pairs of the entries.
     Map(SizeLength, Box<Type>, Box<Type>),
+    /// A fixed sized list.
     Array(u32, Box<Type>),
+    /// A structure type with fields.
     Struct(Fields),
+    /// A sum type.
     Enum(Vec<(String, Fields)>),
+    /// A UTF8 String. It is serialized with the length first followed by the
+    /// encoding of the string.
     String(SizeLength),
+    /// A smart contract name. It is serialized with the length first followed
+    /// by the ASCII encoding of the name.
     ContractName(SizeLength),
+    /// A smart contract receive function name. It is serialized with the length
+    /// first followed by the ASCII encoding of the name.
     ReceiveName(SizeLength),
     /// An unsigned integer encoded using LEB128 with the addition of a
     /// constraint on the maximum number of bytes to use for an encoding.


### PR DESCRIPTION
## Purpose

Support LEB128 signed and unsigned integers and bytes in the contract schema.

## Changes

- Extended the contract schema with ULeb128, ILeb128, ByteList and ByteArray.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

