### PR TITLE
Implement error for error types

### DIFF
--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Implement `Seek` for `Cursor<T>` when `T` implements `HasSize`.
 - Add traits `Serial`, `Deserial`, `SerialCtx` and `DeserialCtx`.
 - Add procedural macros for deriving `Serial` and `Deserial`.
+- Implement `std::error:Error` for error types, when `std` feature is enabled.
 
 ## concordium-contracts-common 3.0.0 (2022-05-17)
 

--- a/concordium-contracts-common/Cargo.toml
+++ b/concordium-contracts-common/Cargo.toml
@@ -47,6 +47,10 @@ version = "0.4"
 optional = true
 version = "0.2"
 
+[dependencies.thiserror]
+optional = true
+version = "1.0"
+
 [dependencies.concordium-contracts-common-derive]
 path = "../concordium-contracts-common-derive"
 version = "*"
@@ -56,7 +60,7 @@ default = ["std"]
 
 std = ["fnv/std"]
 
-derive-serde = ["serde", "serde_json", "std", "base58check", "chrono", "num-bigint", "num-traits"]
+derive-serde = ["serde", "serde_json", "std", "base58check", "chrono", "num-bigint", "num-traits", "thiserror"]
 sdk = ["concordium-contracts-common-derive/sdk"]
 fuzz = ["derive-serde", "arbitrary"]
 

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -78,6 +78,9 @@ impl fmt::Display for AmountParseError {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for AmountParseError {}
+
 /// Parse from string in CCD units. The input string must be of the form
 /// `n[.m]` where `n` and `m` are both digits. The notation `[.m]` indicates
 /// that that part is optional.
@@ -394,6 +397,9 @@ impl fmt::Display for ParseTimestampError {
 }
 
 #[cfg(feature = "derive-serde")]
+impl std::error::Error for ParseTimestampError {}
+
+#[cfg(feature = "derive-serde")]
 /// The FromStr parses the time according to RFC3339.
 impl str::FromStr for Timestamp {
     type Err = ParseTimestampError;
@@ -525,6 +531,9 @@ impl fmt::Display for ParseDurationError {
         }
     }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseDurationError {}
 
 /// Parse a string containing a list of duration measures separated by
 /// whitespaces. A measure is a number followed by the unit (no whitespace
@@ -770,6 +779,9 @@ impl fmt::Display for NewContractNameError {
         }
     }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for NewContractNameError {}
 
 /// A receive name. Expected format: "<contract_name>.<func_name>".
 #[derive(Eq, PartialEq, Copy, Clone, Debug, Hash)]
@@ -1044,6 +1056,9 @@ impl fmt::Display for NewReceiveNameError {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for NewReceiveNameError {}
+
 /// Time at the beginning of the current slot, in miliseconds since unix epoch.
 pub type SlotTime = Timestamp;
 
@@ -1309,6 +1324,13 @@ pub struct ParseError {}
 /// A type alias used to indicate that the value is a result
 /// of parsing from binary via the `Serial` instance.
 pub type ParseResult<A> = Result<A, ParseError>;
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "Parsing failed") }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseError {}
 
 #[cfg(feature = "derive-serde")]
 mod serde_impl {

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1326,7 +1326,7 @@ pub struct ParseError {}
 pub type ParseResult<A> = Result<A, ParseError>;
 
 impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "Parsing failed") }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str("Parsing failed") }
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
## Purpose

Builds on top of https://github.com/Concordium/concordium-contracts-common/pull/46.

Closes https://github.com/Concordium/concordium-contracts-common/issues/43.

## Changes

- Implement `std::error::Error` when the `std` feature is enabled

When compared to https://github.com/Concordium/concordium-contracts-common/pull/46: none of the examples change in size.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

