### PR TITLE
Unify common types from Rust SDK and crypto_common

### DIFF
--- a/concordium-contracts-common-derive/Cargo.toml
+++ b/concordium-contracts-common-derive/Cargo.toml
@@ -15,6 +15,6 @@ sdk = []
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.63", features = [ "full", "extra-traits" ] }
-quote = "=1.0.0"
+syn = { version = "1.0", features = [ "full", "extra-traits" ] }
+quote = "1.0"
 proc-macro2 = "1.0"

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -9,8 +9,8 @@
 - Implement `Ord` for `OwnedReceiveName`.
 - Change the `serde` implementation for `Address` to use `AddressAccount` and `AddressContract` for the tag, matching the one used by Concordium Node.
 - Make `AccountAddressParseError` public when `derive-serde` is enabled.
-- Implement `Display` and `FromStr` for `ContractAddress` formatted as `<index, subindex>`, E.g `<145,0>`.
-- Implement `Display` and `FromStr` for `Address`. The latter attempts to parse a contract address. If this fails it will attempt to parse an `AccountAddress`.
+- Implement `Display` and `FromStr` for `ContractAddress` when `derive-serde` is enabled. The formatting is `<index, subindex>`, E.g `<145,0>` .
+- Implement `Display` and `FromStr` for `Address` when `derive-serde` is enabled. The latter attempts to parse a contract address. If this fails it will attempt to parse an `AccountAddress`.
 - Implement `FromStr` for `OwnedReceiveName`.
 
 ## concordium-contracts-common 3.1.0 (2022-08-04)

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -5,9 +5,9 @@
 - Add type for `ContractIndex` and `ContractSubIndex`.
 - Add `micro_ccd` getter for `Amount`.
 - Add `AccountAddress::get_alias` function for finding account aliases.
-- Implement converters to string for `ContractName`, `OwnedContractName` and a `serde` implementation.
+- Implement converters to string for `ContractName`, `OwnedContractName` and a `serde` implementation when `derive-serde` is enabled.
 - Implement `Ord` for `OwnedReceiveName`.
-- Change the `serde` implementation for `Address` match the one used by the node.
+- Change the `serde` implementation for `Address` to use `AddressAccount` and `AddressContract` for the tag, matching the one used by Concordium Node.
 - Make `AccountAddressParseError` public when `derive-serde` is enabled.
 
 ## concordium-contracts-common 3.1.0 (2022-08-04)

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Add type for `ContractIndex` and `ContractSubIndex`.
+- Add type aliases for `ContractIndex` and `ContractSubIndex`.
 - Add `micro_ccd` getter for `Amount`.
 - Add `AccountAddress::get_alias` function for finding account aliases.
 - Implement converters to string for `ContractName`, `OwnedContractName` and a `serde` implementation when `derive-serde` is enabled.

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Implement `Ord` for `OwnedReceiveName`.
 - Change the `serde` implementation for `Address` to use `AddressAccount` and `AddressContract` for the tag, matching the one used by Concordium Node.
 - Make `AccountAddressParseError` public when `derive-serde` is enabled.
+- Implement `Display` and `FromStr` for `ContractAddress` formatted as `<index, subindex>`, E.g `<145,0>`.
+- Implement `Display` and `FromStr` for `Address`. The latter attempts to parse a contract address. If this fails it will attempt to parse an `AccountAddress`.
+- Implement `FromStr` for `OwnedReceiveName`.
 
 ## concordium-contracts-common 3.1.0 (2022-08-04)
 

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased changes
 
+- Add type for `ContractIndex` and `ContractSubIndex`.
+- Add `micro_ccd` getter for `Amount`.
+- Add `AccountAddress::get_alias` function for finding account aliases.
+- Implement converters to string for `ContractName`, `OwnedContractName` and a `serde` implementation.
+- Implement `Ord` for `OwnedReceiveName`.
+- Change the `serde` implementation for `Address` match the one used by the node.
+- Make `AccountAddressParseError` public when `derive-serde` is enabled.
+
 ## concordium-contracts-common 3.1.0 (2022-08-04)
 
 - Extend schema type with `ULeb128`, `ILeb128`, `ByteList` and `ByteArray`.

--- a/concordium-contracts-common/src/schema.rs
+++ b/concordium-contracts-common/src/schema.rs
@@ -908,7 +908,7 @@ mod impls {
                 }
                 Type::Amount => {
                     let n = Amount::deserial(source)?;
-                    Ok(Value::String(n.micro_ccd.to_string()))
+                    Ok(Value::String(n.micro_ccd().to_string()))
                 }
                 Type::AccountAddress => {
                     let address = AccountAddress::deserial(source)?;

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -20,6 +20,12 @@ pub type HashMap<K, V, S = fnv::FnvBuildHasher> = hashbrown::HashMap<K, V, S>;
 /// the `fnv` hash function.
 pub type HashSet<K, S = fnv::FnvBuildHasher> = hashbrown::HashSet<K, S>;
 
+/// Contract index.
+pub type ContractIndex = u64;
+
+/// Contract subindex.
+pub type ContractSubIndex = u64;
+
 /// Size of an account address when serialized in binary.
 /// NB: This is different from the Base58 representation.
 pub const ACCOUNT_ADDRESS_SIZE: usize = 32;
@@ -618,20 +624,32 @@ impl AccountAddress {
 #[cfg_attr(feature = "derive-serde", derive(SerdeSerialize, SerdeDeserialize))]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct ContractAddress {
-    pub index:    u64,
-    pub subindex: u64,
+    pub index:    ContractIndex,
+    pub subindex: ContractSubIndex,
+}
+
+impl ContractAddress {
+    /// Construct a new contract address from index and subindex.
+    pub fn new(index: ContractIndex, subindex: ContractSubIndex) -> Self {
+        Self {
+            index,
+            subindex,
+        }
+    }
 }
 
 /// Either an address of an account, or contract.
 #[cfg_attr(
     feature = "derive-serde",
     derive(SerdeSerialize, SerdeDeserialize),
-    serde(tag = "type", content = "address", rename_all = "lowercase")
+    serde(tag = "type", content = "address")
 )]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[derive(Eq, Copy, Clone, Debug)]
 pub enum Address {
+    #[serde(rename = "AddressAccount")]
     Account(AccountAddress),
+    #[serde(rename = "AddressContract")]
     Contract(ContractAddress),
 }
 

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1512,12 +1512,12 @@ mod serde_impl {
         }
     }
 
-    /// Error that can occur when parsing a [`ContractAddress`] from a string.
+    /// Error that can occur when parsing an [`Address`] from a string.
     #[derive(Debug, thiserror::Error)]
     pub enum AddressParseError {
         #[error("Failed parsing a contract address: {0}")]
         ContractAddressError(#[from] ContractAddressParseError),
-        #[error("Failed parsing a account address: {0}")]
+        #[error("Failed parsing an account address: {0}")]
         AccountAddressError(#[from] AccountAddressParseError),
     }
 

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -5,14 +5,14 @@ use alloc::{string::String, string::ToString, vec::Vec};
 use arbitrary::Arbitrary;
 use cmp::Ordering;
 #[cfg(not(feature = "std"))]
-use core::{cmp, convert, fmt, hash, iter, num, ops, str};
+use core::{cmp, convert, fmt, hash, iter, ops, str};
 use hash::Hash;
 #[cfg(feature = "derive-serde")]
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 #[cfg(feature = "derive-serde")]
 pub use serde_impl::*;
 #[cfg(feature = "std")]
-use std::{cmp, convert, fmt, hash, iter, num, ops, str};
+use std::{cmp, convert, fmt, hash, iter, ops, str};
 /// Reexport of the `HashMap` from `hashbrown` with the default hasher set to
 /// the `fnv` hash function.
 pub type HashMap<K, V, S = fnv::FnvBuildHasher> = hashbrown::HashMap<K, V, S>;
@@ -657,56 +657,6 @@ impl ContractAddress {
     }
 }
 
-/// Error from parsing Contract address from a string.
-#[derive(Debug)]
-pub enum ContractAddressParseError {
-    MissingStartBracket,
-    MissingEndBracket,
-    ParseIndexIntError(num::ParseIntError),
-    ParseSubIndexIntError(num::ParseIntError),
-    NoComma,
-}
-
-impl fmt::Display for ContractAddressParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use ContractAddressParseError::*;
-        match self {
-            MissingStartBracket => f.write_str("A contract address must start with '<'"),
-            MissingEndBracket => f.write_str("A contract address must end with '>'"),
-            ParseIndexIntError(err) => write!(f, "Failed to parse the index integer: {0}", err),
-            ParseSubIndexIntError(err) => {
-                write!(f, "Failed to parse the subindex integer: {0}", err)
-            }
-            NoComma => f.write_str(" Missing comma separater between index and subindex"),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for ContractAddressParseError {}
-
-/// Parse a ContractAddressWrapper from a string of "<index,subindex>" where
-/// index and subindex are replaced with an u64.
-impl str::FromStr for ContractAddress {
-    type Err = ContractAddressParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if !s.starts_with('<') {
-            return Err(ContractAddressParseError::MissingStartBracket);
-        }
-        if !s.ends_with('>') {
-            return Err(ContractAddressParseError::MissingEndBracket);
-        }
-        let trimmed = &s[1..s.len() - 1];
-        let (index, sub_index) =
-            trimmed.split_once(',').ok_or(ContractAddressParseError::NoComma)?;
-        let index = u64::from_str(index).map_err(ContractAddressParseError::ParseIndexIntError)?;
-        let sub_index =
-            u64::from_str(sub_index).map_err(ContractAddressParseError::ParseSubIndexIntError)?;
-        Ok(ContractAddress::new(index, sub_index))
-    }
-}
-
 /// Either an address of an account, or contract.
 #[cfg_attr(
     feature = "derive-serde",
@@ -728,64 +678,6 @@ impl From<AccountAddress> for Address {
 
 impl From<ContractAddress> for Address {
     fn from(address: ContractAddress) -> Address { Address::Contract(address) }
-}
-
-/// Error from parsing Contract address from a string.
-#[derive(Debug)]
-pub enum AddressParseError {
-    ContractAddressError(ContractAddressParseError),
-    AccountAddressError(AccountAddressParseError),
-}
-
-impl fmt::Display for AddressParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use AddressParseError::*;
-        match self {
-            ContractAddressError(err) => write!(f, "Failed parsing a contract address: {}", err),
-            AccountAddressError(err) => write!(f, "Failed parsing an account address: {}", err),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for AddressParseError {}
-
-impl convert::From<ContractAddressParseError> for AddressParseError {
-    fn from(err: ContractAddressParseError) -> Self { AddressParseError::ContractAddressError(err) }
-}
-
-impl convert::From<AccountAddressParseError> for AddressParseError {
-    fn from(err: AccountAddressParseError) -> Self { AddressParseError::AccountAddressError(err) }
-}
-
-/// Parse a string into an address, by first trying to parse the string as a
-/// contract address string. If this fails, because of missing bracket, it will
-/// try parsing it as an account address string.
-impl str::FromStr for Address {
-    type Err = AddressParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let contract_result = ContractAddress::from_str(s);
-        let address = match contract_result {
-            Ok(contract) => contract.into(),
-            Err(ContractAddressParseError::MissingStartBracket) => {
-                AccountAddress::from_str(s)?.into()
-            }
-            Err(err) => return Err(err.into()),
-        };
-        Ok(address)
-    }
-}
-
-/// Display the Address using contract notation <index,subindex> for contract
-/// addresses and display for account addresses.
-impl fmt::Display for Address {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            Address::Account(a) => a.fmt(f),
-            Address::Contract(c) => c.fmt(f),
-        }
-    }
 }
 
 // This trait is implemented manually to produce fewer bytes in the generated
@@ -1521,7 +1413,7 @@ mod serde_impl {
     use super::*;
     use base58check::*;
     use serde::{de, de::Visitor, Deserializer, Serializer};
-    use std::fmt;
+    use std::{fmt, num};
 
     /// Error type for when parsing an account address.
     #[derive(Debug, thiserror::Error)]
@@ -1537,7 +1429,7 @@ mod serde_impl {
         InvalidByteLength(usize),
     }
 
-    // Parse from string assuming base58 check encoding.
+    /// Parse from string assuming base58check encoding.
     impl str::FromStr for AccountAddress {
         type Err = AccountAddressParseError;
 
@@ -1574,10 +1466,86 @@ mod serde_impl {
             des.deserialize_str(Base58Visitor)
         }
     }
+    /// Error from parsing a `ContractAddress` from a string.
+    #[derive(Debug, thiserror::Error)]
+    pub enum ContractAddressParseError {
+        #[error("A contract address must start with '<'")]
+        MissingStartBracket,
+        #[error("A contract address must end with '>'")]
+        MissingEndBracket,
+        #[error("Failed to parse the index integer: {0}")]
+        ParseIndexIntError(num::ParseIntError),
+        #[error("Failed to parse the subindex integer: {0}")]
+        ParseSubIndexIntError(num::ParseIntError),
+        #[error("Missing comma separater between index and subindex")]
+        NoComma,
+    }
+
+    /// Parse a ContractAddressWrapper from a string of "<index,subindex>" where
+    /// index and subindex are replaced with an u64.
+    impl str::FromStr for ContractAddress {
+        type Err = ContractAddressParseError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            if !s.starts_with('<') {
+                return Err(ContractAddressParseError::MissingStartBracket);
+            }
+            if !s.ends_with('>') {
+                return Err(ContractAddressParseError::MissingEndBracket);
+            }
+            let trimmed = &s[1..s.len() - 1];
+            let (index, sub_index) =
+                trimmed.split_once(',').ok_or(ContractAddressParseError::NoComma)?;
+            let index =
+                u64::from_str(index).map_err(ContractAddressParseError::ParseIndexIntError)?;
+            let sub_index = u64::from_str(sub_index)
+                .map_err(ContractAddressParseError::ParseSubIndexIntError)?;
+            Ok(ContractAddress::new(index, sub_index))
+        }
+    }
 
     impl fmt::Display for ContractAddress {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "<{},{}>", self.index, self.subindex)
+        }
+    }
+
+    /// Error from parsing Contract address from a string.
+    #[derive(Debug, thiserror::Error)]
+    pub enum AddressParseError {
+        #[error("Failed parsing a contract address: {0}")]
+        ContractAddressError(#[from] ContractAddressParseError),
+        #[error("Failed parsing a account address: {0}")]
+        AccountAddressError(#[from] AccountAddressParseError),
+    }
+
+    /// Parse a string into an address, by first trying to parse the string as a
+    /// contract address string. If this fails, because of missing bracket, it
+    /// will try parsing it as an account address string.
+    impl str::FromStr for Address {
+        type Err = AddressParseError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            let contract_result = ContractAddress::from_str(s);
+            let address = match contract_result {
+                Ok(contract) => contract.into(),
+                Err(ContractAddressParseError::MissingStartBracket) => {
+                    AccountAddress::from_str(s)?.into()
+                }
+                Err(err) => return Err(err.into()),
+            };
+            Ok(address)
+        }
+    }
+
+    /// Display the Address using contract notation <index,subindex> for
+    /// contract addresses and display for account addresses.
+    impl fmt::Display for Address {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+            match self {
+                Address::Account(a) => a.fmt(f),
+                Address::Contract(c) => c.fmt(f),
+            }
         }
     }
 

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -622,6 +622,18 @@ impl AccountAddress {
     /// if they identify the same account. This is defined to be when the
     /// addresses agree on the first 29 bytes.
     pub fn is_alias(&self, other: &AccountAddress) -> bool { self.0[0..29] == other.0[0..29] }
+
+    /// Get the `n-th` alias of an address. There are 2^24 possible aliases.
+    /// If the counter is `>= 2^24` then this function will return [`None`].
+    pub fn get_alias(&self, counter: u32) -> Option<Self> {
+        if counter < (1 << 24) {
+            let mut data = self.0;
+            data[29..].copy_from_slice(&counter.to_be_bytes()[1..]);
+            Some(Self(data))
+        } else {
+            None
+        }
+    }
 }
 
 /// Address of a contract.

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -9,9 +9,10 @@ use core::{cmp, convert, fmt, hash, iter, ops, str};
 use hash::Hash;
 #[cfg(feature = "derive-serde")]
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
+#[cfg(feature = "derive-serde")]
+pub use serde_impl::*;
 #[cfg(feature = "std")]
 use std::{cmp, convert, fmt, hash, iter, ops, str};
-
 /// Reexport of the `HashMap` from `hashbrown` with the default hasher set to
 /// the `fnv` hash function.
 pub type HashMap<K, V, S = fnv::FnvBuildHasher> = hashbrown::HashMap<K, V, S>;
@@ -610,6 +611,10 @@ impl convert::AsRef<[u8; 32]> for AccountAddress {
 
 impl convert::AsRef<[u8]> for AccountAddress {
     fn as_ref(&self) -> &[u8] { &self.0 }
+}
+
+impl convert::AsMut<[u8; 32]> for AccountAddress {
+    fn as_mut(&mut self) -> &mut [u8; 32] { &mut self.0 }
 }
 
 impl AccountAddress {

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -21,10 +21,12 @@ pub type HashMap<K, V, S = fnv::FnvBuildHasher> = hashbrown::HashMap<K, V, S>;
 /// the `fnv` hash function.
 pub type HashSet<K, S = fnv::FnvBuildHasher> = hashbrown::HashSet<K, S>;
 
-/// Contract index.
+/// Contract address index. A contract address consists of an index and a
+/// subindex. This type is for the index.
 pub type ContractIndex = u64;
 
-/// Contract subindex.
+/// Contract address subindex. A contract address consists of an index and a
+/// subindex. This type is for the subindex.
 pub type ContractSubIndex = u64;
 
 /// Size of an account address when serialized in binary.
@@ -668,6 +670,14 @@ pub enum Address {
     Account(AccountAddress),
     #[cfg_attr(feature = "derive-serde", serde(rename = "AddressContract"))]
     Contract(ContractAddress),
+}
+
+impl From<AccountAddress> for Address {
+    fn from(address: AccountAddress) -> Address { Address::Account(address) }
+}
+
+impl From<ContractAddress> for Address {
+    fn from(address: ContractAddress) -> Address { Address::Contract(address) }
 }
 
 // This trait is implemented manually to produce fewer bytes in the generated

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1466,7 +1466,8 @@ mod serde_impl {
             des.deserialize_str(Base58Visitor)
         }
     }
-    /// Error from parsing a `ContractAddress` from a string.
+
+    /// Error that can occur when parsing a [`ContractAddress`] from a string.
     #[derive(Debug, thiserror::Error)]
     pub enum ContractAddressParseError {
         #[error("A contract address must start with '<'")]
@@ -1481,8 +1482,9 @@ mod serde_impl {
         NoComma,
     }
 
-    /// Parse a ContractAddressWrapper from a string of "<index,subindex>" where
-    /// index and subindex are replaced with an u64.
+    /// Parse a [`ContractAddress`] from a string of the format
+    /// "<index,subindex>" where index and subindex are [`ContractIndex`]
+    /// and [`ContractSubIndex`], respectively.
     impl str::FromStr for ContractAddress {
         type Err = ContractAddressParseError;
 
@@ -1510,7 +1512,7 @@ mod serde_impl {
         }
     }
 
-    /// Error from parsing Contract address from a string.
+    /// Error that can occur when parsing a [`ContractAddress`] from a string.
     #[derive(Debug, thiserror::Error)]
     pub enum AddressParseError {
         #[error("Failed parsing a contract address: {0}")]
@@ -1519,9 +1521,9 @@ mod serde_impl {
         AccountAddressError(#[from] AccountAddressParseError),
     }
 
-    /// Parse a string into an address, by first trying to parse the string as a
-    /// contract address string. If this fails, because of missing bracket, it
-    /// will try parsing it as an account address string.
+    /// Parse a string into an [`Address`], by first trying to parse the string
+    /// as a contract address string. If this fails, because of missing
+    /// bracket, it will try parsing it as an account address string.
     impl str::FromStr for Address {
         type Err = AddressParseError;
 
@@ -1538,7 +1540,7 @@ mod serde_impl {
         }
     }
 
-    /// Display the Address using contract notation <index,subindex> for
+    /// Display the [`Address`] using contract notation <index,subindex> for
     /// contract addresses and display for account addresses.
     impl fmt::Display for Address {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {


### PR DESCRIPTION
## Purpose

Related to https://github.com/Concordium/concordium-base/issues/180

## Changes

- Match serde implementation with the Rust SDK for `Address`.
- Export `AccountAddressParseError` when `derive-serde` is enabled.
- Add amount unit tests found in base.
- Add `micro_ccd` getter for `Amount`.

Notice the `From<u64> for Amount` was not introduced from base, as the behavior of this might not be obvious.
Instead, the functions `Amount::from_micro_ccd` or `Amount::from_ccd` should be used instead.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
