### PR TITLE
Add `cursor_position` method to `Seek`

### DIFF
--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Add `cursor_position` method to the `Seek` trait.
+
 ## concordium-contracts-common 3.1.0 (2022-08-04)
 
 - Extend schema type with `ULeb128`, `ILeb128`, `ByteList` and `ByteArray`.

--- a/concordium-contracts-common/src/impls.rs
+++ b/concordium-contracts-common/src/impls.rs
@@ -1102,6 +1102,9 @@ impl<T: HasSize> Seek for Cursor<T> {
             }
         }
     }
+
+    #[inline(always)]
+    fn cursor_position(&self) -> u32 { self.offset as u32 }
 }
 
 impl Write for Cursor<&mut Vec<u8>> {

--- a/concordium-contracts-common/src/traits.rs
+++ b/concordium-contracts-common/src/traits.rs
@@ -26,6 +26,9 @@ pub trait Seek {
     /// Seek to the new position. If successful, return the new position from
     /// the beginning of the stream.
     fn seek(&mut self, pos: SeekFrom) -> Result<u32, Self::Err>;
+
+    /// Get the cursor position counted from the beginning of the stream.
+    fn cursor_position(&self) -> u32;
 }
 
 /// The `HasSize` trait provides a function for getting the current byte size.


### PR DESCRIPTION
## Purpose

Add a `cursor_position` method to the `Seek` trait. It was needed for https://github.com/Concordium/concordium-rust-smart-contracts/pull/141.

## Changes

- Add `cursor_position` method and implement it for `Cursor`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.