### PR TITLE
Use bs58 instead of base58check.

### DIFF
--- a/concordium-contracts-common/Cargo.toml
+++ b/concordium-contracts-common/Cargo.toml
@@ -35,9 +35,10 @@ version = "1.0"
 optional = true
 version = "0.4.19"
 
-[dependencies.base58check]
+[dependencies.bs58]
 optional = true
-version = "0.1"
+version = "0.4"
+features = ["check"]
 
 [dependencies.num-bigint]
 optional = true
@@ -59,7 +60,7 @@ version = "1"
 default = ["std"]
 
 std = ["fnv/std"]
-derive-serde = ["serde", "serde_json", "std", "base58check", "chrono", "num-bigint", "num-traits", "thiserror"]
+derive-serde = ["serde", "serde_json", "std", "bs58", "chrono", "num-bigint", "num-traits", "thiserror"]
 sdk = ["concordium-contracts-common-derive/sdk"]
 fuzz = ["derive-serde", "arbitrary"]
 

--- a/concordium-contracts-common/src/schema.rs
+++ b/concordium-contracts-common/src/schema.rs
@@ -136,7 +136,6 @@ pub enum Fields {
     None,
 }
 
-// TODO: Extend with LEB128
 /// Type of the variable used to encode the length of Sets, List, Maps
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1855,8 +1855,8 @@ mod serde_impl {
             let mut address_bytes = [0u8; 32];
 
             for _ in 0..1000 {
-                let address = AccountAddress(address_bytes);
                 rng.fill(&mut address_bytes);
+                let address = AccountAddress(address_bytes);
                 let parsed: AccountAddress =
                     address.to_string().parse().expect("Failed to parse address string.");
                 assert_eq!(


### PR DESCRIPTION
## Purpose

Replace the `base58check` crate with the `bs58` crate.
It is better designed and maintained, and has up-to-date dependencies.

Closes https://github.com/Concordium/concordium-contracts-common/issues/60
