### PR TITLE
Add v2 contract schemas

### DIFF
--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Rework attribute values types (breaking change)
   - Change `AttributeValue` from a slice to a struct.
   - Remove `OwnedAttributeValue` type.
+- Add support for smart contract v2 schemas.
 
 ## concordium-contracts-common 3.1.0 (2022-08-04)
 

--- a/concordium-contracts-common/src/schema.rs
+++ b/concordium-contracts-common/src/schema.rs
@@ -53,9 +53,6 @@ pub struct ModuleV1 {
 
 /// Contains all the contract schemas for a smart contract module V1 with a V2
 /// schema.
-///
-/// Older versions of smart contracts might have this embedded in the custom
-/// section labelled `concordium-schema-v2`.
 #[derive(Debug, Clone)]
 pub struct ModuleV2 {
     pub contracts: BTreeMap<String, ContractV2>,


### PR DESCRIPTION
## Purpose

Adds a v2 schema, which supports schemas for errors.
Part of the solution for https://github.com/Concordium/concordium-rust-smart-contracts/issues/155

## Changes

- Rename some types by adding a `V1` suffix.
- Adding some schema `V2` types and implementing serialization and helpers.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.