### PR TITLE
Add type for ModuleReference

### DIFF
--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- Add type `ModuleReference` representing a module reference.
+- Implement `SchemaType` for `OwnedEntrypointName`.
+
 ## concordium-contracts-common 4.0.0 (2022-08-24)
 
 - Add type aliases for `ContractIndex` and `ContractSubIndex`.

--- a/concordium-contracts-common/src/impls.rs
+++ b/concordium-contracts-common/src/impls.rs
@@ -163,6 +163,17 @@ impl Deserial for Amount {
     }
 }
 
+impl Serial for ModuleReference {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.as_ref().serial(out) }
+}
+
+impl Deserial for ModuleReference {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        let bytes: [u8; 32] = source.get()?;
+        Ok(bytes.into())
+    }
+}
+
 impl Serial for Timestamp {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
         self.timestamp_millis().serial(out)

--- a/concordium-contracts-common/src/schema.rs
+++ b/concordium-contracts-common/src/schema.rs
@@ -390,6 +390,9 @@ impl SchemaType for i128 {
 impl SchemaType for Amount {
     fn get_type() -> Type { Type::Amount }
 }
+impl SchemaType for ModuleReference {
+    fn get_type() -> Type { Type::ByteArray(32) }
+}
 impl SchemaType for AccountAddress {
     fn get_type() -> Type { Type::AccountAddress }
 }
@@ -454,6 +457,10 @@ impl SchemaType for OwnedContractName {
 
 impl SchemaType for OwnedReceiveName {
     fn get_type() -> Type { Type::ReceiveName(SizeLength::U16) }
+}
+
+impl SchemaType for OwnedEntrypointName {
+    fn get_type() -> Type { Type::String(SizeLength::U16) }
 }
 
 impl<A: SchemaType, const N: usize> SchemaType for [A; N] {

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -337,14 +337,17 @@ impl ops::RemAssign<u64> for Amount {
 pub struct ModuleReference([u8; 32]);
 
 impl convert::AsRef<[u8; 32]> for ModuleReference {
+    #[inline(always)]
     fn as_ref(&self) -> &[u8; 32] { &self.0 }
 }
 
 impl convert::From<[u8; 32]> for ModuleReference {
+    #[inline(always)]
     fn from(bytes: [u8; 32]) -> Self { Self(bytes) }
 }
 
 impl convert::From<ModuleReference> for [u8; 32] {
+    #[inline(always)]
     fn from(module: ModuleReference) -> Self { module.0 }
 }
 

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -331,6 +331,23 @@ impl ops::RemAssign<u64> for Amount {
     fn rem_assign(&mut self, other: u64) { *self = *self % other; }
 }
 
+/// A reference to a smart contract module deployed on the chain.
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ModuleReference([u8; 32]);
+
+impl convert::AsRef<[u8; 32]> for ModuleReference {
+    fn as_ref(&self) -> &[u8; 32] { &self.0 }
+}
+
+impl convert::From<[u8; 32]> for ModuleReference {
+    fn from(bytes: [u8; 32]) -> Self { Self(bytes) }
+}
+
+impl convert::From<ModuleReference> for [u8; 32] {
+    fn from(module: ModuleReference) -> Self { module.0 }
+}
+
 /// Timestamp represented as milliseconds since unix epoch.
 ///
 /// Timestamps from before January 1st 1970 at 00:00 are not supported.


### PR DESCRIPTION
## Purpose

- Add type representing a module reference.
- Implement `SchemaType` for `OwnedEntrypointName`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
