### PR TITLE
Add type for exchange rates

### DIFF
--- a/concordium-contracts-common/Cargo.toml
+++ b/concordium-contracts-common/Cargo.toml
@@ -43,6 +43,10 @@ version = "0.1"
 optional = true
 version = "0.4"
 
+[dependencies.num-integer]
+optional = true
+version = "0.1"
+
 [dependencies.num-traits]
 optional = true
 version = "0.2"
@@ -59,7 +63,7 @@ version = "1"
 default = ["std"]
 
 std = ["fnv/std"]
-derive-serde = ["serde", "serde_json", "std", "base58check", "chrono", "num-bigint", "num-traits", "thiserror"]
+derive-serde = ["serde", "serde_json", "std", "base58check", "chrono", "num-bigint", "num-traits", "num-integer", "thiserror"]
 sdk = ["concordium-contracts-common-derive/sdk"]
 fuzz = ["derive-serde", "arbitrary"]
 

--- a/concordium-contracts-common/src/impls.rs
+++ b/concordium-contracts-common/src/impls.rs
@@ -163,6 +163,21 @@ impl Deserial for Amount {
     }
 }
 
+impl Serial for ExchangeRate {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        out.write_u64(self.numerator())?;
+        out.write_u64(self.denominator())
+    }
+}
+
+impl Deserial for ExchangeRate {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        let numerator = source.read_u64()?;
+        let denominator = source.read_u64()?;
+        Ok(ExchangeRate::new_unchecked(numerator, denominator))
+    }
+}
+
 impl Serial for ModuleReference {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.as_ref().serial(out) }
 }
@@ -1099,7 +1114,7 @@ impl<T: HasSize> Seek for Cursor<T> {
                     Err(()) // cannot seek beyond the end
                 } else {
                     // due to two's complement representation of values we do not have to
-                    // distinguish on whether we go forward or backwards. Reinterpreting the bits
+                    // distinguish on whether we gorward or backwards. Reinterpreting the bits
                     // and adding unsigned values is the same as subtracting the
                     // absolute value.
                     let new_offset = end.wrapping_add(delta as u32);


### PR DESCRIPTION
## Purpose

Add `ExchangeRate` type needed for the contract chain queries.

## Changes

- Introduce `ExchangeRate` representing an exchange rate between two quantities.
- Added optional dependency on `num-integer` for the `gcd` function, only when enabling `derive-serde`.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
