### PR TITLE
Bug in enum deserialization.

### DIFF
--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Make the following functions `const`: `Duration::from_millis`, `Duration::from_seconds`, `Duration::from_minutes`, `Duration::from_hours` and `Duration::from_days`.
 - Add `is_account` and `is_contract` methods to the `Address` type.
 - When deserializing according to `Enum` schema type, variant indices were
-  erronously parsed as `u32` when more than 256 enum variants are specified.
+  erroneously parsed as `u32` when more than 256 enum variants are specified.
   These are now parsed as `u16` as intended.
 
 ## concordium-contracts-common 4.0.0 (2022-08-24)

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add type `ExchangeRate` representing an exchange rate between two quantities.
 - Make the following functions `const`: `Duration::from_millis`, `Duration::from_seconds`, `Duration::from_minutes`, `Duration::from_hours` and `Duration::from_days`.
 - Add `is_account` and `is_contract` methods to the `Address` type.
+- Deserialized `Enum` variant indices were erronously output as `u32` when more than `256` enum variants are specified. These are now output as `u16` as intended.
 
 ## concordium-contracts-common 4.0.0 (2022-08-24)
 

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## Unreleased changes
 
-- Add support for smart contract v3 schemas.
+- Add support for smart contract V3 schemas.
 - Add type `ModuleReference` representing a module reference.
 - Implement `SchemaType` for `OwnedEntrypointName` and `OwnedParameter`.
 - Add type `ExchangeRate` representing an exchange rate between two quantities.
 - Make the following functions `const`: `Duration::from_millis`, `Duration::from_seconds`, `Duration::from_minutes`, `Duration::from_hours` and `Duration::from_days`.
 - Add `is_account` and `is_contract` methods to the `Address` type.
-- Deserialized `Enum` variant indices were erronously output as `u32` when more than `256` enum variants are specified. These are now output as `u16` as intended.
+- When deserializing according to `Enum` schema type, variant indices were
+  erronously parsed as `u32` when more than 256 enum variants are specified.
+  These are now parsed as `u16` as intended.
 
 ## concordium-contracts-common 4.0.0 (2022-08-24)
 

--- a/concordium-contracts-common/src/schema_json.rs
+++ b/concordium-contracts-common/src/schema_json.rs
@@ -1049,7 +1049,7 @@ impl Type {
                 let idx = if variants.len() <= 256 {
                     u8::deserial(source)? as usize
                 } else {
-                    u32::deserial(source)? as usize
+                    u16::deserial(source)? as usize
                 };
                 let (name, fields_ty) = variants.get(idx).ok_or_else(ParseError::default)?;
                 let fields = fields_ty.to_json(source)?;


### PR DESCRIPTION
## Purpose

The current implementation serializes enum variant indices using u32 instead of u16.

## Changes

Change type of output.