### PR TITLE
Support chrono 4.23.

### DIFF
--- a/concordium-contracts-common/src/impls.rs
+++ b/concordium-contracts-common/src/impls.rs
@@ -636,7 +636,7 @@ impl SerialCtx for &str {
         out: &mut W,
     ) -> Result<(), W::Err> {
         schema::serial_length(self.len(), size_len, out)?;
-        serial_vector_no_length(&self.as_bytes().to_vec(), out)
+        serial_vector_no_length(self.as_bytes(), out)
     }
 }
 


### PR DESCRIPTION
## Purpose

Do not use functions deprecated in chrono 0.4.23

## Changes

Replace usage of deprecated functions with suggested alternatives.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.