### PR TITLE
Fix schema's to_json for contract addresses.

### DIFF
--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Add methods `serial_value` and `serial_value_into` on the `Type`.
   They are more ergonomic to use than `write_bytes_from_json_schema_type` which
   is marked as deprecated and will be removed in future versions.
+- Fix schema's `to_json` for contract addresses to that it outputs a value in
+  the correct `{"index": ..., "subindex": ...}` format.
 
 ## concordium-contracts-common 5.1.0 (2022-12-14)
 

--- a/concordium-contracts-common/Cargo.toml
+++ b/concordium-contracts-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-contracts-common"
-version = "5.1.0"
+version = "5.1.1"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/concordium-contracts-common/src/schema_json.rs
+++ b/concordium-contracts-common/src/schema_json.rs
@@ -1028,7 +1028,7 @@ impl Type {
             }
             Type::ContractAddress => {
                 let address = ContractAddress::deserial(source)?;
-                Ok(Value::String(address.to_string()))
+                Ok(serde_json::to_value(address).map_err(|_| ParseError {})?)
             }
             Type::Timestamp => {
                 let timestamp = Timestamp::deserial(source)?;


### PR DESCRIPTION
It should output a contract address in the format that is used in JSON everywhere else. Not as a string.

## Purpose

Fixes a bug that makes it so that to_json output cannot be parsed back.

## Changes

Use the correct to_json instance.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.