### PR TITLE
Move `AccountBalance` from `concordium-std` and other small changes

### DIFF
--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased changes
 
 - Implement `quickcheck::Arbitrary` for `Timestamp`, `AccountAddress`, `ContractAddress`, `Address`,  `ChainMetadata`, `AttributeTag`, `AttributeValue` and `OwnedPolicy`.
+- Add `to_owned` method to `EntrypointName` and `ContractName` types.
 
 ## concordium-contracts-common 5.0.0 (2022-11-21)
 

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Implement `quickcheck::Arbitrary` for `Timestamp`, `AccountAddress`, `ContractAddress`, `Address`,  `ChainMetadata`, `AttributeTag`, `AttributeValue` and `OwnedPolicy`.
 - Add `to_owned` method to `EntrypointName` and `ContractName` types.
+- Implement `Serial`/`Deserial` instances for tuples with 4, 5, and 6 elements.
 
 ## concordium-contracts-common 5.0.0 (2022-11-21)
 

--- a/concordium-contracts-common/src/impls.rs
+++ b/concordium-contracts-common/src/impls.rs
@@ -5,10 +5,18 @@ use alloc::{boxed::Box, collections, string::String, vec::Vec};
 use collections::{BTreeMap, BTreeSet};
 use convert::TryFrom;
 #[cfg(not(feature = "std"))]
-use core::{convert, hash, marker, mem::MaybeUninit, slice};
+use core::{
+    convert, hash, marker,
+    mem::{transmute, MaybeUninit},
+    slice,
+};
 use hash::Hash;
 #[cfg(feature = "std")]
-use std::{collections, convert, hash, marker, mem::MaybeUninit, slice};
+use std::{
+    collections, convert, hash, marker,
+    mem::{transmute, MaybeUninit},
+    slice,
+};
 // Implementations of Serialize
 
 impl<X: Serial, Y: Serial> Serial for (X, Y) {
@@ -178,6 +186,26 @@ impl Serial for Amount {
 impl Deserial for Amount {
     fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
         source.read_u64().map(Amount::from_micro_ccd)
+    }
+}
+
+impl Serial for AccountBalance {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        self.total.serial(out)?;
+        self.staked.serial(out)?;
+        self.locked.serial(out)?;
+        Ok(())
+    }
+}
+
+impl Deserial for AccountBalance {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        let bytes: [u8; 24] = source.read_array()?;
+        let chunks = unsafe { transmute::<[u8; 24], [[u8; 8]; 3]>(bytes) };
+        let total = Amount::from_micro_ccd(u64::from_le_bytes(chunks[0]));
+        let staked = Amount::from_micro_ccd(u64::from_le_bytes(chunks[1]));
+        let locked = Amount::from_micro_ccd(u64::from_le_bytes(chunks[2]));
+        Self::new(total, staked, locked).ok_or_else(ParseError::default)
     }
 }
 

--- a/concordium-contracts-common/src/impls.rs
+++ b/concordium-contracts-common/src/impls.rs
@@ -19,39 +19,6 @@ use std::{
 };
 // Implementations of Serialize
 
-impl<X: Serial, Y: Serial> Serial for (X, Y) {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        self.0.serial(out)?;
-        self.1.serial(out)
-    }
-}
-
-impl<X: Deserial, Y: Deserial> Deserial for (X, Y) {
-    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
-        let x = X::deserial(source)?;
-        let y = Y::deserial(source)?;
-        Ok((x, y))
-    }
-}
-
-impl<X: Deserial, Y: Deserial, Z: Deserial> Deserial for (X, Y, Z) {
-    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
-        let x = source.get()?;
-        let y = source.get()?;
-        let z = source.get()?;
-        Ok((x, y, z))
-    }
-}
-
-impl<X: Serial, Y: Serial, Z: Serial> Serial for (X, Y, Z) {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        self.0.serial(out)?;
-        self.1.serial(out)?;
-        self.2.serial(out)?;
-        Ok(())
-    }
-}
-
 impl Serial for () {
     #[inline(always)]
     fn serial<W: Write>(&self, _out: &mut W) -> Result<(), W::Err> { Ok(()) }
@@ -60,6 +27,109 @@ impl Serial for () {
 impl Deserial for () {
     #[inline(always)]
     fn deserial<R: Read>(_source: &mut R) -> ParseResult<Self> { Ok(()) }
+}
+
+impl<A: Serial, B: Serial> Serial for (A, B) {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        self.0.serial(out)?;
+        self.1.serial(out)
+    }
+}
+
+impl<A: Deserial, B: Deserial> Deserial for (A, B) {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        let a = source.get()?;
+        let b = source.get()?;
+        Ok((a, b))
+    }
+}
+
+impl<X: Deserial, Y: Deserial, Z: Deserial> Deserial for (X, Y, Z) {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        let a = source.get()?;
+        let b = source.get()?;
+        let c = source.get()?;
+        Ok((a, b, c))
+    }
+}
+
+impl<A: Serial, B: Serial, C: Serial> Serial for (A, B, C) {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        self.0.serial(out)?;
+        self.1.serial(out)?;
+        self.2.serial(out)?;
+        Ok(())
+    }
+}
+
+impl<A: Deserial, B: Deserial, C: Deserial, D: Deserial> Deserial for (A, B, C, D) {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        let a = source.get()?;
+        let b = source.get()?;
+        let c = source.get()?;
+        let d = source.get()?;
+        Ok((a, b, c, d))
+    }
+}
+
+impl<A: Serial, B: Serial, C: Serial, D: Serial> Serial for (A, B, C, D) {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        self.0.serial(out)?;
+        self.1.serial(out)?;
+        self.2.serial(out)?;
+        self.3.serial(out)?;
+        Ok(())
+    }
+}
+
+impl<A: Deserial, B: Deserial, C: Deserial, D: Deserial, E: Deserial> Deserial for (A, B, C, D, E) {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        let a = source.get()?;
+        let b = source.get()?;
+        let c = source.get()?;
+        let d = source.get()?;
+        let e = source.get()?;
+        Ok((a, b, c, d, e))
+    }
+}
+
+impl<A: Serial, B: Serial, C: Serial, D: Serial, E: Serial> Serial for (A, B, C, D, E) {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        self.0.serial(out)?;
+        self.1.serial(out)?;
+        self.2.serial(out)?;
+        self.3.serial(out)?;
+        self.4.serial(out)?;
+        Ok(())
+    }
+}
+
+impl<A: Deserial, B: Deserial, C: Deserial, D: Deserial, E: Deserial, F: Deserial> Deserial
+    for (A, B, C, D, E, F)
+{
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        let a = source.get()?;
+        let b = source.get()?;
+        let c = source.get()?;
+        let d = source.get()?;
+        let e = source.get()?;
+        let f = source.get()?;
+        Ok((a, b, c, d, e, f))
+    }
+}
+
+impl<A: Serial, B: Serial, C: Serial, D: Serial, E: Serial, F: Serial> Serial
+    for (A, B, C, D, E, F)
+{
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        self.0.serial(out)?;
+        self.1.serial(out)?;
+        self.2.serial(out)?;
+        self.3.serial(out)?;
+        self.4.serial(out)?;
+        self.5.serial(out)?;
+        Ok(())
+    }
 }
 
 impl Serial for u8 {

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -225,11 +225,18 @@ impl Amount {
         }
     }
 
-    /// Checked addition. Adds another amount and return None if overflow
-    /// occurred
+    /// Checked addition. Adds another amount and returns None if overflow
+    /// occurred.
     #[inline(always)]
     pub fn checked_add(self, other: Amount) -> Option<Amount> {
         self.micro_ccd.checked_add(other.micro_ccd).map(Amount::from_micro_ccd)
+    }
+
+    /// Checked subtraction. Subtracts another amount and returns None if
+    /// underflow occurred.
+    #[inline(always)]
+    pub fn checked_sub(self, other: Amount) -> Option<Amount> {
+        self.micro_ccd.checked_sub(other.micro_ccd).map(Amount::from_micro_ccd)
     }
 
     /// Add a number of CCD to an amount

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -854,6 +854,10 @@ impl<'a> ContractName<'a> {
     #[inline(always)]
     pub fn get_chain_name(self) -> &'a str { self.0 }
 
+    /// Convert a `ContractName` to its owned counterpart. This is an expensive
+    /// operation that requires memory allocation.
+    pub fn to_owned(&self) -> OwnedContractName { OwnedContractName(self.0.to_owned()) }
+
     /// Extract the contract name by removing the "init_" prefix.
     #[inline(always)]
     pub fn contract_name(self) -> &'a str { self.get_chain_name().strip_prefix("init_").unwrap() }
@@ -1094,6 +1098,10 @@ impl<'a> EntrypointName<'a> {
         is_valid_entrypoint_name(name)?;
         Ok(Self(name))
     }
+
+    /// Convert a `EntrypointName` to its owned counterpart. This is an
+    /// expensive operation that requires memory allocation.
+    pub fn to_owned(&self) -> OwnedEntrypointName { OwnedEntrypointName(self.0.to_owned()) }
 
     /// Create a new name. **This does not check the format and is therefore
     /// unsafe.** It is provided for convenience since sometimes it is

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1200,11 +1200,18 @@ impl From<Vec<u8>> for OwnedParameter {
 }
 
 impl OwnedParameter {
+    /// Get [`Self`] as the borrowed variant [`Parameter`].
     pub fn as_parameter(&self) -> Parameter { Parameter(self.0.as_ref()) }
 
-    /// Construct an `OwnedParameter` by serializing the input using its
+    /// Construct an [`Self`]` by serializing the input using its
     /// `Serial` instance.
     pub fn new<D: Serial>(data: &D) -> Self { Self(to_bytes(data)) }
+
+    /// Construct an [`Self`] from a vector of bytes.
+    pub fn from_bytes(bytes: Vec<u8>) -> Self { Self(bytes) }
+
+    /// Construct an empty [`Self`].
+    pub fn empty() -> Self { Self(Vec::new()) }
 }
 
 /// Check whether the given string is a valid contract entrypoint name.


### PR DESCRIPTION
## Purpose

A few smaller changes that I needed when working on https://github.com/Concordium/concordium-smart-contract-tools/pull/23.

## Changes

- Move `AccountBalance` from `concordium-std`.
- Add `to_owned` method to `EntrypointName` and `ContractName` types.
- Add `checked_sub` to `Amount` type.
- Add `from_bytes` and `empty` constructor methods to `OwnedParameter`.
- Add serialization instances for 4, 5, and 6 tuples.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.