### PR TITLE
Unify parameter and module reference types

### DIFF
--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -11,6 +11,10 @@
   implementation for getting the raw bytes.
   - Migrate from `parameter.0`: use `Parameter.into()` instead (for both of the affected
     types).
+- For `ModuleReference`, replace `AsRef<[u8;32]>` with `AsRef<[u8]>` and make
+  inner bytes public.
+  - The change was necessary for internal reasons.
+  - Migrate from `module_reference.as_ref()`: use `module_reference.bytes` instead.
 
 ## concordium-contracts-common 5.2.0 (2023-02-08)
 

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -11,10 +11,14 @@
   owned variants.
 - Add `Display` implementation for `OwnedParameter` and `Parameter`, which uses
   hex encoding.
-- Replace `From` instance for `OwnedParameter`/`Parameter` with a `TryFrom`,
+- Replace `From<Vec<u8>>` instance for `OwnedParameter`/`Parameter` with a `TryFrom`,
   which ensures a valid length, and the unchecked method `new_unchecked`.
   - Migrate from `From`/`Into`: Use `new_unchecked` instead (if known to be
     valid length).
+- Make inner field in `OwnedParameter`/`Parameter` private, but add an `From`
+  implementation for getting the raw bytes.
+  - Migrate from `parameter.0`: use `Parameter.into()` instead (for both of the affected
+    types).
 
 ## concordium-contracts-common 5.1.0 (2022-12-14)
 

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -9,6 +9,12 @@
   the correct `{"index": ..., "subindex": ...}` format.
 - Add `Display` implementations for `ContractName`, `ReceiveName`, and their
   owned variants.
+- Add `Display` implementation for `OwnedParameter` and `Parameter`, which uses
+  hex encoding.
+- Replace `From` instance for `OwnedParameter`/`Parameter` with a `TryFrom`,
+  which ensures a valid length, and the unchecked method `new_unchecked`.
+  - Migrate from `From`/`Into`: Use `new_unchecked` instead (if known to be
+    valid length).
 
 ## concordium-contracts-common 5.1.0 (2022-12-14)
 

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -14,7 +14,7 @@
 - For `ModuleReference`, replace `AsRef<[u8;32]>` with `AsRef<[u8]>` and make
   inner bytes public.
   - The change was necessary for internal reasons.
-  - Migrate from `module_reference.as_ref()`: use `module_reference.bytes` instead.
+  - Migrate from `module_reference.as_ref()`: use `&module_reference.bytes` instead.
 
 ## concordium-contracts-common 5.2.0 (2023-02-08)
 

--- a/concordium-contracts-common/src/constants.rs
+++ b/concordium-contracts-common/src/constants.rs
@@ -4,3 +4,6 @@
 pub const MAX_FUNC_NAME_SIZE: usize = 100;
 
 pub(crate) static MAX_PREALLOCATED_CAPACITY: usize = 4096;
+
+/// Maximum allowed length of a smart contract parameter.
+pub const MAX_PARAMETER_LEN: usize = 65535;

--- a/concordium-contracts-common/src/constants.rs
+++ b/concordium-contracts-common/src/constants.rs
@@ -7,3 +7,6 @@ pub(crate) static MAX_PREALLOCATED_CAPACITY: usize = 4096;
 
 /// Maximum allowed length of a smart contract parameter.
 pub const MAX_PARAMETER_LEN: usize = 65535;
+
+/// Size of a sha256 digest in bytes.
+pub const SHA256: usize = 32;

--- a/concordium-contracts-common/src/hashes.rs
+++ b/concordium-contracts-common/src/hashes.rs
@@ -1,0 +1,194 @@
+//! Different types of hashes based on SHA256.
+
+use crate::constants::SHA256;
+#[cfg(all(feature = "derive-serde", not(feature = "std")))]
+use core::str::FromStr;
+#[cfg(not(feature = "std"))]
+use core::{
+    convert::{TryFrom, TryInto},
+    fmt, hash,
+    marker::PhantomData,
+    ops::Deref,
+};
+#[cfg(feature = "derive-serde")]
+use serde;
+#[cfg(all(feature = "derive-serde", feature = "std"))]
+use std::str::FromStr;
+#[cfg(feature = "std")]
+use std::{
+    convert::{TryFrom, TryInto},
+    fmt, hash,
+    marker::PhantomData,
+    ops::Deref,
+};
+
+#[derive(Ord, PartialOrd, Copy)]
+#[cfg_attr(feature = "derive-serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "derive-serde", serde(into = "String"))]
+#[repr(transparent)]
+/// A general wrapper around Sha256 hash. This is used to add type safety to
+/// a hash that is used in different context. The underlying value is always the
+/// same, but the phantom type variable makes it impossible to mistakenly misuse
+/// the hashes.
+pub struct HashBytes<Purpose> {
+    pub bytes: [u8; SHA256 as usize],
+    #[cfg_attr(feature = "derive-serde", serde(skip))] // use default when deserializing
+    _phantom:  PhantomData<Purpose>,
+}
+
+impl<Purpose> PartialEq for HashBytes<Purpose> {
+    fn eq(&self, other: &Self) -> bool { self.bytes == other.bytes }
+}
+
+impl<Purpose> Eq for HashBytes<Purpose> {}
+
+impl<Purpose> hash::Hash for HashBytes<Purpose> {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) { self.bytes.hash(state); }
+}
+
+impl<Purpose> Clone for HashBytes<Purpose> {
+    fn clone(&self) -> Self {
+        Self {
+            bytes:    self.bytes,
+            _phantom: Default::default(),
+        }
+    }
+}
+
+#[doc(hidden)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+/// Used as a phantom type to indicate a hash is a block hash.
+pub enum ModuleReferenceMarker {}
+
+/// A reference to a smart contract module deployed on the chain.
+pub type ModuleReference = HashBytes<ModuleReferenceMarker>;
+
+#[cfg(feature = "derive-serde")]
+#[derive(Debug, thiserror::Error)]
+/// Possible errors when converting from a string to any kind of hash.
+/// String representation of hashes is as base 16.
+pub enum HashFromStrError {
+    #[cfg_attr(feature = "derive-serde", error("Not a valid hex string: {0}"))]
+    HexDecodeError(#[from] hex::FromHexError),
+    #[cfg_attr(feature = "derive-serde", error("Incorrect length, found {found}, expected 32."))]
+    IncorrectLength {
+        // length that was found
+        found: usize,
+    },
+}
+
+impl<Purpose> HashBytes<Purpose> {
+    /// Construct [`HashBytes`] from a slice.
+    pub fn new(bytes: [u8; SHA256 as usize]) -> Self {
+        Self {
+            bytes,
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<Purpose> From<[u8; 32]> for HashBytes<Purpose> {
+    fn from(array: [u8; 32]) -> Self { Self::new(array) }
+}
+
+impl<Purpose> Deref for HashBytes<Purpose> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target { &self.bytes }
+}
+
+impl<Purpose> AsRef<[u8]> for HashBytes<Purpose> {
+    fn as_ref(&self) -> &[u8] { self }
+}
+
+#[cfg(feature = "derive-serde")]
+impl<Purpose> FromStr for HashBytes<Purpose> {
+    type Err = HashFromStrError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let hex_decoded = hex::decode(s)?;
+        let found = hex_decoded.len();
+        let bytes = hex_decoded.try_into().map_err(|_| HashFromStrError::IncorrectLength {
+            found,
+        })?;
+        Ok(HashBytes::new(bytes))
+    }
+}
+
+#[cfg(feature = "derive-serde")]
+impl<Purpose> TryFrom<&str> for HashBytes<Purpose> {
+    type Error = HashFromStrError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> { Self::from_str(value) }
+}
+
+#[derive(Debug)]
+#[cfg_attr(feature = "derive-serde", derive(thiserror::Error))]
+#[cfg_attr(feature = "derive-serde", error("Slice has incompatible length with a hash."))]
+pub struct IncorrectLength;
+
+impl<Purpose> TryFrom<&[u8]> for HashBytes<Purpose> {
+    type Error = IncorrectLength;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        let bytes: [u8; SHA256 as usize] = value.try_into().map_err(|_| IncorrectLength)?;
+        Ok(bytes.into())
+    }
+}
+
+// NB: Using try_from = &str does not work correctly for HashBytes
+// serde::Deserialize instance due to ownership issues for the JSON format.
+// Hence we implement this manually. The issue is that a &'a str cannot be
+// deserialized from a String for arbitrary 'a, and this is needed when
+// parsing with serde_json::from_value via &'a str.
+#[cfg(feature = "derive-serde")]
+impl<'de, Purpose> serde::Deserialize<'de> for HashBytes<Purpose> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>, {
+        struct HashBytesVisitor<Purpose> {
+            _phantom: PhantomData<Purpose>,
+        }
+
+        impl<'de, Purpose> serde::de::Visitor<'de> for HashBytesVisitor<Purpose> {
+            type Value = HashBytes<Purpose>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "A hex string.")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                HashBytes::try_from(v).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_str(HashBytesVisitor {
+            _phantom: Default::default(),
+        })
+    }
+}
+
+#[cfg(feature = "derive-serde")]
+impl<Purpose> From<HashBytes<Purpose>> for String {
+    fn from(x: HashBytes<Purpose>) -> String { x.to_string() }
+}
+
+// a short, 8-character beginning of the SHA
+impl<Purpose> fmt::Debug for HashBytes<Purpose> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for byte in self.iter().take(4) {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+// the full SHA256 in hex
+impl<Purpose> fmt::Display for HashBytes<Purpose> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for byte in self.iter() {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}

--- a/concordium-contracts-common/src/impls.rs
+++ b/concordium-contracts-common/src/impls.rs
@@ -202,7 +202,7 @@ impl Deserial for ExchangeRate {
 }
 
 impl Serial for ModuleReference {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { out.write_all(self) }
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { out.write_all(self.as_ref()) }
 }
 
 impl Deserial for ModuleReference {

--- a/concordium-contracts-common/src/impls.rs
+++ b/concordium-contracts-common/src/impls.rs
@@ -202,7 +202,7 @@ impl Deserial for ExchangeRate {
 }
 
 impl Serial for ModuleReference {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.as_ref().serial(out) }
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { out.write_all(self) }
 }
 
 impl Deserial for ModuleReference {

--- a/concordium-contracts-common/src/lib.rs
+++ b/concordium-contracts-common/src/lib.rs
@@ -88,6 +88,7 @@ mod traits;
 #[macro_use]
 mod impls;
 pub mod constants;
+pub mod hashes;
 pub mod schema;
 #[cfg(feature = "derive-serde")]
 pub mod schema_json;

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1176,6 +1176,7 @@ impl OwnedEntrypointName {
 }
 
 /// Parameter to the init function or entrypoint.
+#[repr(transparent)]
 #[derive(Eq, PartialEq, Debug, Clone, Copy, Hash)]
 pub struct Parameter<'a>(pub(crate) &'a [u8]);
 
@@ -1214,7 +1215,16 @@ impl fmt::Display for Parameter<'_> {
     }
 }
 
+impl<'a> Parameter<'a> {
+    /// Construct a parameter from a slice of bytes without checking that it
+    /// fits the size limit. The caller is assumed to ensure this via
+    /// external means.
+    #[inline]
+    pub fn new_unchecked(bytes: &'a [u8]) -> Self { Self(bytes) }
+}
+
 /// Parameter to the init function or entrypoint. Owned version.
+#[repr(transparent)]
 #[derive(Eq, PartialEq, Debug, Clone, Hash, Default)]
 #[cfg_attr(feature = "derive-serde", derive(SerdeSerialize, SerdeDeserialize))]
 pub struct OwnedParameter(

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1200,6 +1200,10 @@ impl<'a> convert::TryFrom<&'a [u8]> for Parameter<'a> {
     }
 }
 
+impl<'a> From<Parameter<'a>> for &'a [u8] {
+    fn from(p: Parameter<'a>) -> Self { p.0 }
+}
+
 /// Display the entire parameter in hex.
 impl fmt::Display for Parameter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1248,6 +1252,10 @@ impl convert::TryFrom<Vec<u8>> for OwnedParameter {
             })
         }
     }
+}
+
+impl From<OwnedParameter> for Vec<u8> {
+    fn from(op: OwnedParameter) -> Self { op.0 }
 }
 
 /// Display the entire parameter in hex.

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1177,31 +1177,87 @@ impl OwnedEntrypointName {
 
 /// Parameter to the init function or entrypoint.
 #[derive(Eq, PartialEq, Debug, Clone, Copy, Hash)]
-pub struct Parameter<'a>(pub &'a [u8]);
-
-impl<'a> From<&'a [u8]> for Parameter<'a> {
-    #[inline(always)]
-    fn from(param: &'a [u8]) -> Self { Self(param) }
-}
+pub struct Parameter<'a>(pub(crate) &'a [u8]);
 
 impl<'a> AsRef<[u8]> for Parameter<'a> {
     #[inline(always)]
     fn as_ref(&self) -> &[u8] { self.0 }
 }
 
+impl<'a> convert::TryFrom<&'a [u8]> for Parameter<'a> {
+    type Error = ExceedsParameterSize;
+
+    fn try_from(bytes: &'a [u8]) -> Result<Self, Self::Error> {
+        let actual = bytes.len();
+        if actual <= constants::MAX_PARAMETER_LEN {
+            Ok(Self(bytes))
+        } else {
+            Err(ExceedsParameterSize {
+                actual,
+                max: constants::MAX_PARAMETER_LEN,
+            })
+        }
+    }
+}
+
+/// Display the entire parameter in hex.
+impl fmt::Display for Parameter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in self.0.iter() {
+            f.write_fmt(format_args!("{:02x}", b))?
+        }
+        Ok(())
+    }
+}
+
 /// Parameter to the init function or entrypoint. Owned version.
-#[derive(Eq, PartialEq, Debug, Clone, Hash)]
-pub struct OwnedParameter(pub Vec<u8>);
+#[derive(Eq, PartialEq, Debug, Clone, Hash, Default)]
+#[cfg_attr(feature = "derive-serde", derive(SerdeSerialize, SerdeDeserialize))]
+pub struct OwnedParameter(
+    #[cfg_attr(feature = "derive-serde", serde(with = "serde_impl::byte_array_hex"))]
+    pub(crate)  Vec<u8>,
+);
+
+#[derive(Debug)]
+#[cfg_attr(feature = "derive-serde", derive(thiserror::Error))]
+#[cfg_attr(
+    feature = "derive-serde",
+    error("The byte array of size {actual} is too large to fit into parameter size limit {max}.")
+)]
+pub struct ExceedsParameterSize {
+    pub actual: usize,
+    pub max:    usize,
+}
 
 impl AsRef<[u8]> for OwnedParameter {
     #[inline(always)]
     fn as_ref(&self) -> &[u8] { self.0.as_ref() }
 }
 
-/// Convert the vector into a parameter as is.
-impl From<Vec<u8>> for OwnedParameter {
-    #[inline(always)]
-    fn from(param: Vec<u8>) -> Self { Self(param) }
+impl convert::TryFrom<Vec<u8>> for OwnedParameter {
+    type Error = ExceedsParameterSize;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        let actual = bytes.len();
+        if actual <= constants::MAX_PARAMETER_LEN {
+            Ok(Self(bytes))
+        } else {
+            Err(ExceedsParameterSize {
+                actual,
+                max: constants::MAX_PARAMETER_LEN,
+            })
+        }
+    }
+}
+
+/// Display the entire parameter in hex.
+impl fmt::Display for OwnedParameter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in &self.0 {
+            f.write_fmt(format_args!("{:02x}", b))?
+        }
+        Ok(())
+    }
 }
 
 impl OwnedParameter {
@@ -1210,6 +1266,12 @@ impl OwnedParameter {
     /// Construct an `OwnedParameter` by serializing the input using its
     /// `Serial` instance.
     pub fn new<D: Serial>(data: &D) -> Self { Self(to_bytes(data)) }
+
+    /// Construct a parameter from a vector of bytes without checking that it
+    /// fits the size limit. The caller is assumed to ensure this via
+    /// external means.
+    #[inline]
+    pub fn new_unchecked(bytes: Vec<u8>) -> Self { Self(bytes) }
 }
 
 /// Check whether the given string is a valid contract entrypoint name.
@@ -2002,6 +2064,36 @@ mod serde_impl {
     impl<'de> SerdeDeserialize<'de> for AccountAddress {
         fn deserialize<D: Deserializer<'de>>(des: D) -> Result<Self, D::Error> {
             des.deserialize_str(Base58Visitor)
+        }
+    }
+
+    /// Helper for [de]serializing a byte array as an hex string.
+    pub(super) mod byte_array_hex {
+        use super::*;
+
+        /// Serialize (via Serde)
+        pub fn serialize<S: serde::Serializer>(dt: &[u8], ser: S) -> Result<S::Ok, S::Error> {
+            ser.serialize_str(hex::encode(dt).as_str())
+        }
+
+        /// Deserialize (via Serde)
+        pub fn deserialize<'de, D: serde::Deserializer<'de>>(des: D) -> Result<Vec<u8>, D::Error> {
+            struct HexVisitor;
+            impl<'de> serde::de::Visitor<'de> for HexVisitor {
+                type Value = Vec<u8>;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    write!(formatter, "A hex string.")
+                }
+
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error, {
+                    let r = hex::decode(v).map_err(serde::de::Error::custom)?;
+                    Ok(r)
+                }
+            }
+            des.deserialize_str(HexVisitor)
         }
     }
 

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1,3 +1,4 @@
+pub use crate::hashes::ModuleReference;
 use crate::{constants, to_bytes, Serial};
 #[cfg(all(not(feature = "std"), feature = "concordium-quickcheck"))]
 use alloc::{boxed::Box, collections::BTreeMap};
@@ -346,26 +347,6 @@ impl ops::MulAssign<u64> for Amount {
 impl ops::RemAssign<u64> for Amount {
     #[inline(always)]
     fn rem_assign(&mut self, other: u64) { *self = *self % other; }
-}
-
-/// A reference to a smart contract module deployed on the chain.
-#[repr(transparent)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ModuleReference([u8; 32]);
-
-impl convert::AsRef<[u8; 32]> for ModuleReference {
-    #[inline(always)]
-    fn as_ref(&self) -> &[u8; 32] { &self.0 }
-}
-
-impl convert::From<[u8; 32]> for ModuleReference {
-    #[inline(always)]
-    fn from(bytes: [u8; 32]) -> Self { Self(bytes) }
-}
-
-impl convert::From<ModuleReference> for [u8; 32] {
-    #[inline(always)]
-    fn from(module: ModuleReference) -> Self { module.0 }
 }
 
 /// Timestamp represented as milliseconds since unix epoch.


### PR DESCRIPTION
## Purpose

For legacy reasons, we have two pairs of types that are nearly identical.
Namely, the `Parameter` from concordium-base (not to be confused by the borrowing `Parameter` from this repo) and `OwnedParameter` from this repo.
And `ModuleRef` from concordium-base and `ModuleReference` from this repo.

This pull request addresses that issue.
Closes #74 

## Changes

- Unify the parameter types
  - Try to match the old API to avoid breaking changes. See changelog for details.
- Unify the module reference types:
   - Move the `HashBytes` type from base to here and use it for the `ModuleReference`.
   - Try to match the old API to avoid breaking changes. See changelog for details.


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.