### PR TITLE
Rename `new` to `from_serial` which ensures valid length

### DIFF
--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -7,14 +7,19 @@
   which ensures a valid length, and the unchecked method `new_unchecked`.
   - Migrate from `From`/`Into`: Use `new_unchecked` instead (if known to be
     valid length).
-- Make inner field in `OwnedParameter`/`Parameter` private, but add an `From`
+- Make inner field in `OwnedParameter`/`Parameter` private, but add a `From`
   implementation for getting the raw bytes.
-  - Migrate from `parameter.0`: use `Parameter.into()` instead (for both of the affected
+  - Migrate from `parameter.0`: use `parameter.into()` instead (for both of the affected
     types).
 - For `ModuleReference`, replace `AsRef<[u8;32]>` with `AsRef<[u8]>` and make
-  inner bytes public.
+  inner `bytes` public.
   - The change was necessary for internal reasons.
   - Migrate from `module_reference.as_ref()`: use `&module_reference.bytes` instead.
+- Replace `OwnedParameter::new` with `OwnedParameter::from_serial`, which also
+  ensures a valid length.
+  - Migrate from `new(x)`: Use `from_serial(x).unwrap()` (if known to be valid length).
+- Add an `empty` method for both `OwnedParameter` and `Parameter`.
+- Implement `Default` for `Parameter`.
 
 ## concordium-contracts-common 5.2.0 (2023-02-08)
 

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1205,7 +1205,7 @@ impl<'a> Parameter<'a> {
 
     /// Construct an empty parameter.
     #[inline]
-    pub fn empty() -> Self { Self::default() }
+    pub fn empty() -> Self { Self(&[]) }
 }
 
 /// Parameter to the init function or entrypoint. Owned version.
@@ -1290,7 +1290,7 @@ impl OwnedParameter {
 
     /// Construct an empty parameter.
     #[inline]
-    pub fn empty() -> Self { Self::default() }
+    pub fn empty() -> Self { Self(Vec::new()) }
 }
 
 /// Check whether the given string is a valid contract entrypoint name.

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1158,7 +1158,7 @@ impl OwnedEntrypointName {
 
 /// Parameter to the init function or entrypoint.
 #[repr(transparent)]
-#[derive(Eq, PartialEq, Debug, Clone, Copy, Hash)]
+#[derive(Eq, PartialEq, Debug, Clone, Copy, Hash, Default)]
 pub struct Parameter<'a>(pub(crate) &'a [u8]);
 
 impl<'a> AsRef<[u8]> for Parameter<'a> {
@@ -1202,6 +1202,10 @@ impl<'a> Parameter<'a> {
     /// external means.
     #[inline]
     pub fn new_unchecked(bytes: &'a [u8]) -> Self { Self(bytes) }
+
+    /// Construct an empty parameter.
+    #[inline]
+    pub fn empty() -> Self { Self::default() }
 }
 
 /// Parameter to the init function or entrypoint. Owned version.
@@ -1264,13 +1268,29 @@ impl OwnedParameter {
 
     /// Construct an `OwnedParameter` by serializing the input using its
     /// `Serial` instance.
-    pub fn new<D: Serial>(data: &D) -> Self { Self(to_bytes(data)) }
+    ///
+    /// Returns an error if the serialized parameter exceeds
+    /// [`MAX_PARAMETER_LEN`][constants::MAX_PARAMETER_LEN].
+    pub fn from_serial<D: Serial>(data: &D) -> Result<Self, ExceedsParameterSize> {
+        let bytes = to_bytes(data);
+        if bytes.len() > constants::MAX_PARAMETER_LEN {
+            return Err(ExceedsParameterSize {
+                actual: bytes.len(),
+                max:    constants::MAX_PARAMETER_LEN,
+            });
+        }
+        Ok(Self(bytes))
+    }
 
     /// Construct a parameter from a vector of bytes without checking that it
     /// fits the size limit. The caller is assumed to ensure this via
     /// external means.
     #[inline]
     pub fn new_unchecked(bytes: Vec<u8>) -> Self { Self(bytes) }
+
+    /// Construct an empty parameter.
+    #[inline]
+    pub fn empty() -> Self { Self::default() }
 }
 
 /// Check whether the given string is a valid contract entrypoint name.


### PR DESCRIPTION
## Purpose

Replace `new` with `from_serial` which also checks the length.

## Changes

- Rename `new` to `from_serial` which ensures valid length
- Also add empty methods to both versions of parameter
- And implement Default for parameter

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.