### PR TITLE
Fix schema JSON deserialization of signed integers

### DIFF
--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Fix schema JSON deserialization of negative signed numbers.
+
 ## concordium-contracts-common 5.3.0 (2023-03-16)
 
 - Add `Display` implementation for `OwnedParameter` and `Parameter`, which uses

--- a/concordium-contracts-common/src/schema_json.rs
+++ b/concordium-contracts-common/src/schema_json.rs
@@ -114,7 +114,7 @@ fn write_bytes_from_json_schema_type<W: Write>(
         }
         Type::I8 => {
             if let Value::Number(n) = json {
-                let n = n.as_u64().ok_or(JsonError::SignedIntRequired)?;
+                let n = n.as_i64().ok_or(JsonError::SignedIntRequired)?;
                 let n: i8 = n.try_into()?;
                 serial!(n, out)
             } else {
@@ -123,7 +123,7 @@ fn write_bytes_from_json_schema_type<W: Write>(
         }
         Type::I16 => {
             if let Value::Number(n) = json {
-                let n = n.as_u64().ok_or(JsonError::SignedIntRequired)?;
+                let n = n.as_i64().ok_or(JsonError::SignedIntRequired)?;
                 let n: i16 = n.try_into()?;
                 serial!(n, out)
             } else {
@@ -132,7 +132,7 @@ fn write_bytes_from_json_schema_type<W: Write>(
         }
         Type::I32 => {
             if let Value::Number(n) = json {
-                let n = n.as_u64().ok_or(JsonError::SignedIntRequired)?;
+                let n = n.as_i64().ok_or(JsonError::SignedIntRequired)?;
                 let n: i32 = n.try_into()?;
                 serial!(n, out)
             } else {
@@ -141,7 +141,7 @@ fn write_bytes_from_json_schema_type<W: Write>(
         }
         Type::I64 => {
             if let Value::Number(n) = json {
-                let n = n.as_u64().ok_or(JsonError::SignedIntRequired)?;
+                let n = n.as_i64().ok_or(JsonError::SignedIntRequired)?;
                 serial!(n, out)
             } else {
                 Err(WrongJsonType("JSON number required".to_string()))


### PR DESCRIPTION
## Purpose

This PR fixes schema JSON deserealization of signed numbers.

## Changes

`.as_u64()` was used to parse signed numbers, which caused a failure when supplied with a negative value. This was replaced by `.as_i64()`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
