### PR TITLE
Remove Copy requirement.

### DIFF
--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased changes
 
+- Remove the `Copy` requirement for deserialization of BTreeMap and BTreeSet.
+  This allows using non-copyable (and non-clonable) types as map keys or set
+  values.
+
+## concordium-contracts-common 5.3.1 (2023-04-12)
+
 - Fix schema JSON deserialization of negative signed numbers.
 - Add `PartialEq` implementations for comparing `ReceiveName`, `ContractName`, and
   `EntrypointName` and their owned variants to `str`.


### PR DESCRIPTION
## Purpose

Fixes https://github.com/Concordium/concordium-rust-smart-contracts/issues/242

In particular this allows using TokenIdVec as map keys.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
