### PR TITLE
Remove `sdk` feature, update version and edition, add helper function

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,6 +10,10 @@ on:
 
 name: Clippy & fmt
 
+env:
+  RUST_VERSION: "1.60"
+  RUST_FMT: "nightly-2023-04-01"
+
 jobs:
   rustfmt:
     name: Format
@@ -22,7 +26,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-06-09
+          toolchain: ${{ env.RUST_FMT }}
           override: true
           components: rustfmt
 
@@ -55,7 +59,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.target }}
           override: true
           components: clippy
@@ -85,7 +89,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.target }}
           override: true
           components: clippy
@@ -107,7 +111,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56
+          toolchain: ${{ env.RUST_VERSION }}
           override: true
 
       - name: Run cargo test

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -46,7 +46,6 @@ jobs:
           - "std"
           - "derive-serde"
           - "fuzz"
-          - "sdk"
           - "concordium-quickcheck"
         target:
           - wasm32-unknown-unknown
@@ -75,9 +74,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        features:
-          - ""
-          - "sdk"
         target:
           - wasm32-unknown-unknown
           - x86_64-unknown-linux-gnu
@@ -98,7 +94,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --manifest-path=concordium-contracts-common-derive/Cargo.toml --target=${{ matrix.target }} --features=${{ matrix.features }} --no-default-features -- -D warnings
+          args: --manifest-path=concordium-contracts-common-derive/Cargo.toml --target=${{ matrix.target }} --no-default-features -- -D warnings
 
   test:
     name: x86_64 tests on concordium-contracts-common

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# Concordium Contracts Common library
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](https://github.com/Concordium/.github/blob/main/.github/CODE_OF_CONDUCT.md)
 
@@ -21,9 +22,35 @@ The functionality in this library is re-exported via the [concordium-std](https:
 
 ## MSRV
 
-The minimum supported rust version is 1.56
+The minimum supported rust version is 1.60.
 
 ## Links
 
 - [Crates.io](https://crates.io/crates/concordium-contracts-common)
 - [Documentation](https://docs.rs/concordium-contracts-common/latest/concordium_contracts_common/)
+
+## Contributing
+
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](https://github.com/Concordium/.github/blob/main/.github/CODE_OF_CONDUCT.md)
+
+This repository's CI automatically checks formatting and common problems in rust.
+Changes to any of the packages must be such that
+
+- ```cargo clippy --all``` produces no warnings
+- ```rustfmt``` makes no changes.
+
+Everything in this repository should build with rust version 1.60 however the `fmt` tool must be from a nightly release since some of the configuration options are not stable. One way to run the `fmt` tool is
+```
+cargo +nightly-2023-04-01 fmt
+```
+
+(the exact version used by the CI can be found in [.github/workflows/linter.yml](.github/workflows/linter.yml) file).
+You will need to have a recent enough nightly version installed, which can be done via
+
+```
+rustup toolchain install nightly-2023-04-01
+```
+
+or similar, using the [rustup](https://rustup.rs/) tool. See the documentation of the tool for more details.
+
+In order to contribute you should make a pull request and ask at least two people familiar with the code to do a review.

--- a/concordium-contracts-common-derive/CHANGELOG.md
+++ b/concordium-contracts-common-derive/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased changes
+- Set minimum Rust version to 1.60.
+- Set Rust edition to 2021.
 
 ## concordium-contracts-common-derive 1.0.1 (2022-08-24)
 

--- a/concordium-contracts-common-derive/CHANGELOG.md
+++ b/concordium-contracts-common-derive/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased changes
 - Set minimum Rust version to 1.60.
 - Set Rust edition to 2021.
+- Remove the `sdk` feature.
+  - Migrate by adding `use concordium_rust_sdk::types::smart_contracts::concordium_contracts_common as concordium_std;`
+    in the files where you derive `Serial` or `Deserial` with the help from this crate.
 
 ## concordium-contracts-common-derive 1.0.1 (2022-08-24)
 

--- a/concordium-contracts-common-derive/Cargo.toml
+++ b/concordium-contracts-common-derive/Cargo.toml
@@ -2,7 +2,8 @@
 name = "concordium-contracts-common-derive"
 authors = ["Concordium <developers@concordium.com>"]
 version = "1.0.1"
-edition = "2018"
+edition = "2021"
+rust-version = "1.60"
 license = "MPL-2.0"
 description = "Procedural macros to ease writing for smart contracts on the Concordium blockchain."
 homepage = "https://github.com/Concordium/concordium-contracts-common"

--- a/concordium-contracts-common-derive/Cargo.toml
+++ b/concordium-contracts-common-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "concordium-contracts-common-derive"
 authors = ["Concordium <developers@concordium.com>"]
-version = "1.0.1"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.60"
 license = "MPL-2.0"

--- a/concordium-contracts-common-derive/Cargo.toml
+++ b/concordium-contracts-common-derive/Cargo.toml
@@ -10,9 +10,6 @@ homepage = "https://github.com/Concordium/concordium-contracts-common"
 repository = "https://github.com/Concordium/concordium-contracts-common"
 readme = "README.md"
 
-[features]
-sdk = []
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 proc-macro = true

--- a/concordium-contracts-common-derive/src/lib.rs
+++ b/concordium-contracts-common-derive/src/lib.rs
@@ -19,12 +19,6 @@ const VALID_CONCORDIUM_FIELD_ATTRIBUTES: [&str; 3] = ["size_length", "ensure_ord
 /// A list of valid concordium attributes
 const VALID_CONCORDIUM_ATTRIBUTES: [&str; 1] = ["state_parameter"];
 
-#[cfg(feature = "sdk")]
-fn get_root() -> proc_macro2::TokenStream {
-    quote!(concordium_rust_sdk::types::smart_contracts::concordium_contracts_common)
-}
-
-#[cfg(not(feature = "sdk"))]
 fn get_root() -> proc_macro2::TokenStream { quote!(concordium_std) }
 
 /// A helper to report meaningful compilation errors

--- a/concordium-contracts-common-derive/src/lib.rs
+++ b/concordium-contracts-common-derive/src/lib.rs
@@ -292,7 +292,7 @@ fn impl_deserial(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
                 matches_tokens.extend(quote! {
                     #idx_lit => {
                         #field_tokens
-                        Ok(#data_name::#variant_ident#pattern)
+                        Ok(#data_name::#variant_ident #pattern)
                     },
                 })
             }
@@ -463,7 +463,7 @@ fn impl_serial(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
                 let variant_ident = &variant.ident;
 
                 matches_tokens.extend(quote! {
-                    #data_name::#variant_ident#pattern => {
+                    #data_name::#variant_ident #pattern => {
                         #root::Serial::serial(&#idx_lit, #out_ident)?;
                         #field_tokens
                     },

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Add the method `serial_for_smart_contracts` to `OwnedPolicy`, which serializes the policy for easy consumption by smart contracts.
 - Set minimum Rust version to 1.60.
 - Set Rust edition to 2021.
+- Remove the `sdk` feature.
+  - Migrate by adding `use concordium_rust_sdk::types::smart_contracts::concordium_contracts_common as concordium_std;`
+    in the files where you derive `Serial` or `Deserial` with the help from this crate.
 
 ## concordium-contracts-common 5.3.1 (2023-04-12)
 

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Remove the `Copy` requirement for deserialization of BTreeMap and BTreeSet.
   This allows using non-copyable (and non-clonable) types as map keys or set
   values.
+- Add the method `serial_for_smart_contracts` to `OwnedPolicy`, which serializes the policy for easy consumption by smart contracts.
 
 ## concordium-contracts-common 5.3.1 (2023-04-12)
 

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -6,6 +6,8 @@
   This allows using non-copyable (and non-clonable) types as map keys or set
   values.
 - Add the method `serial_for_smart_contracts` to `OwnedPolicy`, which serializes the policy for easy consumption by smart contracts.
+- Set minimum Rust version to 1.60.
+- Set Rust edition to 2021.
 
 ## concordium-contracts-common 5.3.1 (2023-04-12)
 

--- a/concordium-contracts-common/Cargo.toml
+++ b/concordium-contracts-common/Cargo.toml
@@ -2,7 +2,8 @@
 name = "concordium-contracts-common"
 version = "5.3.1"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.60"
 license = "MPL-2.0"
 description = "Common functionality used by smart contracts and the host environment on the Concordium blockchain."
 homepage = "https://github.com/Concordium/concordium-contracts-common"

--- a/concordium-contracts-common/Cargo.toml
+++ b/concordium-contracts-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-contracts-common"
-version = "5.3.1"
+version = "6.0.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2021"
 rust-version = "1.60"
@@ -65,7 +65,7 @@ version = "1.0"
 
 [dependencies.concordium-contracts-common-derive]
 path = "../concordium-contracts-common-derive"
-version = "1"
+version = "2"
 
 [dependencies.hex]
 optional = true

--- a/concordium-contracts-common/Cargo.toml
+++ b/concordium-contracts-common/Cargo.toml
@@ -77,7 +77,6 @@ default = ["std"]
 std = ["fnv/std"]
 concordium-quickcheck = ["getrandom", "quickcheck"]
 derive-serde = ["serde", "serde_json", "std", "bs58", "chrono", "num-bigint", "num-traits", "num-integer", "rust_decimal", "thiserror", "hex"]
-sdk = ["concordium-contracts-common-derive/sdk"]
 fuzz = ["derive-serde", "arbitrary"]
 
 [lib]

--- a/concordium-contracts-common/src/hashes.rs
+++ b/concordium-contracts-common/src/hashes.rs
@@ -33,7 +33,7 @@ use std::{
 pub struct HashBytes<Purpose> {
     pub bytes: [u8; SHA256],
     #[cfg_attr(feature = "derive-serde", serde(skip))] // use default when deserializing
-    _phantom:  PhantomData<Purpose>,
+    _phantom: PhantomData<Purpose>,
 }
 
 impl<Purpose> PartialEq for HashBytes<Purpose> {

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -492,7 +492,6 @@ impl str::FromStr for Timestamp {
     type Err = ParseTimestampError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use convert::TryInto;
         let datetime =
             chrono::DateTime::parse_from_rfc3339(s).map_err(ParseTimestampError::ParseError)?;
         let millis = datetime
@@ -2137,8 +2136,6 @@ mod serde_impl {
         type Err = ExchangeRateConversionError;
 
         fn from_str(s: &str) -> Result<Self, Self::Err> {
-            use convert::TryInto;
-
             let mut decimal = rust_decimal::Decimal::from_str_exact(s)?;
             decimal.normalize_assign();
             if decimal.is_zero() || decimal.is_sign_negative() {

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1765,6 +1765,29 @@ repeat_macro!(
 /// since the values are easier to construct.
 pub type OwnedPolicy = Policy<Vec<(AttributeTag, AttributeValue)>>;
 
+impl OwnedPolicy {
+    /// Serialize the policy for easy consumption by a smart contract.
+    ///
+    /// This entails the following serialization scheme:
+    /// - `1`:             u8            specifying a single policy.
+    /// - `len`:           u16           length of the inner payload
+    /// - `inner payload`: `len` bytes   the serialized `OwnedPolicy`
+    pub fn serial_for_smart_contract<W: crate::traits::Write>(
+        &self,
+        out: &mut W,
+    ) -> Result<(), W::Err> {
+        // Serialize to an inner vector.
+        let inner = to_bytes(self);
+        // Specify that there is only one policy.
+        out.write_u8(1)?;
+        // Write length of the inner.
+        (inner.len() as u16).serial(out)?;
+        // Write the inner buffer.
+        out.write_all(&inner)?;
+        Ok(())
+    }
+}
+
 /// Index of the identity provider on the chain.
 /// An identity provider with the given index will not be replaced,
 /// so this is a stable identifier.

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1765,12 +1765,13 @@ repeat_macro!(
 pub type OwnedPolicy = Policy<Vec<(AttributeTag, AttributeValue)>>;
 
 impl OwnedPolicy {
-    /// Serialize the policy for easy consumption by a smart contract.
+    /// Serialize the policy for consumption by smart contract execution engine.
     ///
     /// This entails the following serialization scheme:
     /// - `1`:             u8            specifying a single policy.
     /// - `len`:           u16           length of the inner payload
     /// - `inner payload`: `len` bytes   the serialized `OwnedPolicy`
+    #[doc(hidden)]
     pub fn serial_for_smart_contract<W: crate::traits::Write>(
         &self,
         out: &mut W,


### PR DESCRIPTION
## Purpose

A number of small changes needed for the integration testing library.

## Changes

- Add the method
- The newest version of `rust-decimal` requires rust 1.60, so the rust version is also updated.
- Update the Rust edition to `2021`
  - Used `cargo fix --edition` to put spaces in the macros.
- Update rust version in CI 
- Add contributor section in README which also explains the nightly version needed for `cargo fmt`
- Remove the SDK feature

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.