### PR TITLE
Improve serialization errors

### DIFF
--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## Unreleased changes
 
 - Implement `serde::Serialize` and `serde::Deserialize` for `Duration` using `FromStr` and `Display` implementations, when feature `derive-serde` is enabled.
 

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## concordium-contracts-common 7.0.0 (2023-05-23)
+## Unreleased
 
 - Implement `serde::Serialize` and `serde::Deserialize` for `Duration` using `FromStr` and `Display` implementations, when feature `derive-serde` is enabled.
+
+### Breaking changes
 - Adds new error type `ToJsonError`, which is returned when deserializing to schema type fails.
 - Adds member `JsonError::TraceError` to `JsonError`, which adds trace information to the error produced when serializing from schema type fails.
 

--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## Unreleased changes
+## concordium-contracts-common 7.0.0 (2023-05-23)
 
 - Implement `serde::Serialize` and `serde::Deserialize` for `Duration` using `FromStr` and `Display` implementations, when feature `derive-serde` is enabled.
+- Adds new error type `ToJsonError`, which is returned when deserializing to schema type fails.
+- Adds member `JsonError::TraceError` to `JsonError`, which adds trace information to the error produced when serializing from schema type fails.
 
 ## concordium-contracts-common 6.0.0 (2023-05-08)
 

--- a/concordium-contracts-common/Cargo.toml
+++ b/concordium-contracts-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-contracts-common"
-version = "7.0.0"
+version = "6.0.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2021"
 rust-version = "1.60"

--- a/concordium-contracts-common/Cargo.toml
+++ b/concordium-contracts-common/Cargo.toml
@@ -36,7 +36,7 @@ version = "1.0"
 
 [dependencies.chrono]
 optional = true
-version = "0.4.19"
+version = "0.4"
 
 [dependencies.bs58]
 optional = true

--- a/concordium-contracts-common/Cargo.toml
+++ b/concordium-contracts-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-contracts-common"
-version = "6.0.0"
+version = "7.0.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2021"
 rust-version = "1.60"

--- a/concordium-contracts-common/src/schema_json.rs
+++ b/concordium-contracts-common/src/schema_json.rs
@@ -48,11 +48,27 @@ pub enum JsonError {
 }
 
 impl JsonError {
+    /// Wraps a [JsonError] in a [JsonError::TraceError], providing a trace to the origin of the
+    /// error.
     fn add_trace(&self, trace: String) -> Self {
         JsonError::TraceError {
             trace,
             error: Box::new(self.clone()),
         }
+    }
+
+    /// Gets the underlying error of a [JsonError::TraceError]. For any other variant, this simply returns
+    /// the error itself.
+    fn get_error(&self) -> Self {
+        if let JsonError::TraceError {
+            error,
+            ..
+        } = self
+        {
+            return error.get_error();
+        }
+
+        *self
     }
 }
 

--- a/concordium-contracts-common/src/schema_json.rs
+++ b/concordium-contracts-common/src/schema_json.rs
@@ -76,7 +76,7 @@ pub enum JsonError {
     ParseIntError(#[from] std::num::ParseIntError),
     ParseDurationError(#[from] ParseDurationError),
     ParseTimestampError(#[from] ParseTimestampError),
-    /// Trace leading to the original [JsonError].
+    /// Trace leading to the original [`JsonError`].
     TraceError {
         field: String,
         json:  serde_json::Value,
@@ -147,7 +147,7 @@ impl TraceError for JsonError {
 }
 
 impl JsonError {
-    /// Wraps a [JsonError] in a [JsonError::TraceError], providing a trace to
+    /// Wraps a [`JsonError`] in a [`JsonError::TraceError`], providing a trace to
     /// the origin of the error.
     fn add_trace(self, field: String, json: &serde_json::Value) -> Self {
         JsonError::TraceError {
@@ -157,7 +157,7 @@ impl JsonError {
         }
     }
 
-    /// Prints a formatted error message for variant. [JsonError::TraceError]
+    /// Prints a formatted error message for variant. [`JsonError::TraceError`]
     /// supports printing a verbose form including a more detailed
     /// description of the error stack, which is returned if `verbose` is
     /// set to true.
@@ -1431,7 +1431,7 @@ fn item_list_to_json<T: AsRef<[u8]>>(
     Ok(values)
 }
 
-/// Deserialize a [String] of variable length from `source`.
+/// Deserialize a [`String`] of variable length from `source`.
 fn deserial_string<R: Read>(
     source: &mut R,
     size_len: SizeLength,
@@ -1812,7 +1812,7 @@ impl Type {
     }
 }
 
-/// Deserialize a uleb128 encoded [BigUint] from `source`.
+/// Deserialize a uleb128 encoded [`BigUint`] from `source`.
 fn deserial_biguint<R: Read>(source: &mut R, constraint: u32) -> ParseResult<BigUint> {
     let mut result = BigUint::zero();
     let mut shift = 0;
@@ -1829,7 +1829,7 @@ fn deserial_biguint<R: Read>(source: &mut R, constraint: u32) -> ParseResult<Big
     Err(ParseError {})
 }
 
-/// Deserialize a ileb128 encoded [BigInt] from `source`.
+/// Deserialize a ileb128 encoded [`BigInt`] from `source`.
 fn deserial_bigint<R: Read>(source: &mut R, constraint: u32) -> ParseResult<BigInt> {
     let mut result = BigInt::zero();
     let mut shift = 0;

--- a/concordium-contracts-common/src/schema_json.rs
+++ b/concordium-contracts-common/src/schema_json.rs
@@ -133,7 +133,7 @@ pub enum JsonError {
     /// Trace leading to the original [`JsonError`].
     TraceError {
         field: String,
-        json: serde_json::Value,
+        json:  serde_json::Value,
         error: Box<JsonError>,
     },
 }
@@ -258,15 +258,11 @@ impl JsonError {
     /// ]"#.to_string();
     /// assert_eq!(expected_verbose, err.display(true));
     /// ```
-    pub fn display(&self, verbose: bool) -> String {
-        self.display_nested(verbose)
-    }
+    pub fn display(&self, verbose: bool) -> String { self.display_nested(verbose) }
 
     /// Gets the underlying error of a [`JsonError::TraceError`]. For any other
     /// variant, this simply returns the error itself.
-    pub fn get_error(&self) -> &Self {
-        self.get_innermost_error()
-    }
+    pub fn get_error(&self) -> &Self { self.get_innermost_error() }
 }
 
 /// Wrapper around a list of bytes to represent data which failed to be
@@ -285,9 +281,7 @@ impl From<Vec<u8>> for ToJsonErrorData {
 }
 
 impl From<ToJsonErrorData> for Vec<u8> {
-    fn from(value: ToJsonErrorData) -> Self {
-        value.bytes
-    }
+    fn from(value: ToJsonErrorData) -> Self { value.bytes }
 }
 
 impl Display for ToJsonErrorData {
@@ -357,15 +351,15 @@ pub enum ToJsonError {
     /// Failed to deserialize data to type expected from schema.
     DeserialError {
         position: u32,
-        schema: Type,
-        reason: String,
-        data: ToJsonErrorData,
+        schema:   Type,
+        reason:   String,
+        data:     ToJsonErrorData,
     },
     /// Trace leading to the original [ToJsonError].
     TraceError {
         position: u32,
-        schema: Type,
-        error: Box<ToJsonError>,
+        schema:   Type,
+        error:    Box<ToJsonError>,
     },
 }
 
@@ -442,7 +436,7 @@ impl ToJsonError {
     ///
     /// # Examples
     ///
-    /// ## Display error from list of objects
+    /// ## Display error from failing to deserialize to list of objects
     ///
     /// ```
     /// # use serde_json::json;
@@ -455,6 +449,9 @@ impl ToJsonError {
     /// let mut list_bytes = vec![2, 0];
     /// list_bytes.extend_from_slice(&account_bytes);
     /// list_bytes.extend_from_slice(&contract_bytes);
+    /// // r#"<error-message>
+    /// // In deserializing position <cursor-position> into type Struct(...)
+    /// // In deserializing position <cursor-position> into type List(...)"#;
     /// list_bytes.extend_from_slice(&account_bytes);
     /// list_bytes.extend_from_slice(&contract_bytes[..10]); // Malformed contract address.
 
@@ -464,31 +461,24 @@ impl ToJsonError {
     ///     ("b".into(), Type::ContractAddress),
     /// ]));
     /// let schema = Type::List(SizeLength::U8, Box::new(schema_object));
-    /// let err = schema.to_json(&mut cursor).expect_err("Deserializing should fail");
+    /// let err = schema.to_json(&mut cursor)
+    ///                 .expect_err("Deserializing should fail");
     ///
     /// // The error format points to the position in the byte sequence that
-    /// // failed to deserialize.
-    /// let show_bytes = hex::encode(&list_bytes);
-    /// # #[rustfmt::skip]
-    /// let expected = format!(r#"List(U8, Struct(Named([("a", AccountAddress), ("b", ContractAddress)]))) -> Struct(Named([("a", AccountAddress), ("b", ContractAddress)])) -> Failed to deserialize ContractAddress due to: Could not parse ContractAddress from value as not enough data was available (needs 16 bytes) - from position 81 of bytes {}"#, &show_bytes).to_string();
-    /// assert_eq!(expected, err.display(false));
+    /// // failed to deserialize:
+    /// err.display(false); // "List(...) -> Struct(...) -> <error-message>");
     ///
-    /// // Or if verbose, includes a stacktrace-like format.
-    /// # #[rustfmt::skip]
-    /// let expected_verbose = format!(r#"Failed to deserialize ContractAddress due to: Could not parse ContractAddress from value as not enough data was available (needs 16 bytes) - from position 81 of bytes {}
-    /// In deserializing position 49 into type Struct(Named([("a", AccountAddress), ("b", ContractAddress)]))
-    /// In deserializing position 0 into type List(U8, Struct(Named([("a", AccountAddress), ("b", ContractAddress)])))"#, &show_bytes);
-    /// assert_eq!(expected_verbose, err.display(true));
+    /// // Or if verbose, includes a stacktrace-like format, similar to:
+    /// // r#"<error-message>
+    /// // In deserializing position <cursor-position> into type Struct(...)
+    /// // In deserializing position <cursor-position> into type List(...)"#;
+    /// err.display(true);
     /// ```
-    pub fn display(&self, verbose: bool) -> String {
-        self.display_nested(verbose)
-    }
+    pub fn display(&self, verbose: bool) -> String { self.display_nested(verbose) }
 
     /// Gets the underlying error of a [`ToJsonError::TraceError`]. For any
     /// other variant, this simply returns the error itself.
-    pub fn get_error(&self) -> &Self {
-        self.get_innermost_error()
-    }
+    pub fn get_error(&self) -> &Self { self.get_innermost_error() }
 }
 
 /// Error with the sole purpose of adding some context to [`ParseError`].
@@ -1500,14 +1490,11 @@ mod tests {
         let schema = Type::AccountAddress;
         let err = schema.to_json(&mut cursor).expect_err("Deserializing should fail");
 
-        assert!(matches!(
-            err,
-            ToJsonError::DeserialError {
-                position: 0,
-                schema: Type::AccountAddress,
-                ..
-            }
-        ))
+        assert!(matches!(err, ToJsonError::DeserialError {
+            position: 0,
+            schema: Type::AccountAddress,
+            ..
+        }))
     }
 
     /// Tests that attempting to deserialize a malformed value wrapped in a
@@ -1614,9 +1601,7 @@ impl Fields {
 }
 
 impl From<std::string::FromUtf8Error> for ParseError {
-    fn from(_: std::string::FromUtf8Error) -> Self {
-        ParseError::default()
-    }
+    fn from(_: std::string::FromUtf8Error) -> Self { ParseError::default() }
 }
 
 /// Deserialize a list of values corresponding to the `item_to_json` function

--- a/concordium-contracts-common/src/schema_json.rs
+++ b/concordium-contracts-common/src/schema_json.rs
@@ -121,6 +121,27 @@ impl<'a> ToJsonError<'a> {
             error: Box::new(self),
         }
     }
+
+    /// Prints a formatted error message for variant. [ToJsonError::TraceError] supports printing a
+    /// verbose form including a more detailed description of the error stack, which is returned if
+    /// `verbose` is set to true.
+    pub fn print(&self, verbose: bool) -> String {
+        match self {
+            ToJsonError::TraceError {
+                position,
+                schema,
+                error,
+            } if verbose => {
+                format!(
+                    "{}\nIn deserializing position {} into type {:?}",
+                    error.print(verbose),
+                    position,
+                    schema
+                )
+            }
+            _ => format!("{}", self),
+        }
+    }
 }
 
 pub type ToJsonResult<'a, A> = Result<A, ToJsonError<'a>>;

--- a/concordium-contracts-common/src/schema_json.rs
+++ b/concordium-contracts-common/src/schema_json.rs
@@ -5,6 +5,7 @@ use num_traits::Zero;
 use serde_json::Value;
 use std::convert::{TryFrom, TryInto};
 
+/// Represents errors occuring while serializing data from schema JSON format
 #[derive(Debug, thiserror::Error, Clone)]
 pub enum JsonError<'a> {
     #[error("Failed writing")]
@@ -41,6 +42,7 @@ pub enum JsonError<'a> {
     ParseDurationError(#[from] ParseDurationError),
     #[error("{0}")]
     ParseTimestampError(#[from] ParseTimestampError),
+    /// Trace leading to the original [JsonError].
     #[error("{field} -> {error}")]
     TraceError {
         field: String,
@@ -94,6 +96,8 @@ impl<'a> JsonError<'a> {
     }
 }
 
+/// Wrapper around a list of bytes to represent data which failed to be
+/// deserialized into schema type.
 #[derive(Debug, Clone)]
 pub struct ToJsonErrorData(Vec<u8>);
 
@@ -107,16 +111,20 @@ impl Display for ToJsonErrorData {
     }
 }
 
+/// Represents errors occuring while deserializing to schema JSON format
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum ToJsonError<'a> {
+    /// JSON formatter failed to represent value.
     #[error("Failed to format as JSON")]
     FormatError {},
+    /// Failed to deserialize data to type expected from schema.
     #[error("Failed to deserialize {schema:?} from position {position} of bytes {data}")]
     DeserialError {
         position: u32,
         schema:   &'a Type,
         data:     ToJsonErrorData,
     },
+    /// Trace leading to the original [ToJsonError].
     #[error("{schema:?} -> {error}")]
     TraceError {
         position: u32,

--- a/concordium-contracts-common/src/schema_json.rs
+++ b/concordium-contracts-common/src/schema_json.rs
@@ -6,9 +6,12 @@ use serde_json::Value;
 use std::convert::{TryFrom, TryInto};
 
 trait TraceError {
+    /// Returns an error message layer associated with this error, along with a
+    /// reference to the error this error wraps. If this error is not a
+    /// wrapping layer, None is expected to be returned.
     fn print_layer(&self, verbose: bool) -> (String, Option<&Self>);
 
-    /// Prints a formatted error message for a [TraceError].
+    /// Returns a formatted error message for a [TraceError].
     /// It supports printing a verbose form including a more detailed
     /// description of the error stack, which is returned if `verbose` is
     /// set to true.
@@ -40,6 +43,8 @@ trait TraceError {
         out
     }
 
+    /// Gets a reference to the error this error wraps. If this error is not a
+    /// wrapping layer, None is expected to be returned.
     fn get_inner_error(&self) -> Option<&Self>;
 
     /// Gets the innermost error of a [TraceError].

--- a/concordium-contracts-common/src/schema_json.rs
+++ b/concordium-contracts-common/src/schema_json.rs
@@ -1006,6 +1006,8 @@ mod tests {
         assert!(matches!(err, JsonError::FailedParsingAccountAddress))
     }
 
+    /// Tests that attempting to serialize a non-[AccountAddress] value with
+    /// [Type::AccountAddress] schema results in error of expected type.
     #[test]
     fn test_serial_account_wrong_type_fails() {
         let schema = Type::AccountAddress;
@@ -1015,6 +1017,9 @@ mod tests {
         assert!(matches!(err, JsonError::WrongJsonType(_)))
     }
 
+    /// Tests that attempting to serialize a malformed value wrapped in a
+    /// [Type::List] results in a nested error with trace information in the
+    /// wrapping layer.
     #[test]
     fn test_serial_list_fails_with_trace() {
         let account_bytes = [0u8; ACCOUNT_ADDRESS_SIZE];
@@ -1033,6 +1038,9 @@ mod tests {
         ));
     }
 
+    /// Tests that attempting to serialize a malformed value wrapped in a
+    /// [Type::Struct] results in a nested error with trace information in the
+    /// wrapping layer.
     #[test]
     fn test_serial_object_fails_with_trace() {
         let account_bytes = [0u8; ACCOUNT_ADDRESS_SIZE];
@@ -1054,6 +1062,9 @@ mod tests {
         ));
     }
 
+    /// Tests that attempting to serialize a malformed value wrapped in multiple
+    /// layers results in a nested error with trace information in the
+    /// wrapping layers.
     #[test]
     fn test_serial_fails_with_nested_trace() {
         let account_bytes = [0u8; ACCOUNT_ADDRESS_SIZE];
@@ -1225,6 +1236,8 @@ mod tests {
         assert_eq!(expected, value)
     }
 
+    /// Tests that attempting to deserialize a non-[AccountAddress] value with
+    /// [Type::AccountAddress] schema results in an error of expected format.
     #[test]
     fn test_deserial_malformed_account_address_fails() {
         let account_bytes = [0u8; ACCOUNT_ADDRESS_SIZE];
@@ -1239,6 +1252,8 @@ mod tests {
         }))
     }
 
+    /// Tests that attempting to deserialize a malformed value wrapped in a
+    /// [Type::List] fails with a nested error.
     #[test]
     fn test_deserial_malformed_list_fails() {
         let account_bytes = [0u8; ACCOUNT_ADDRESS_SIZE];
@@ -1266,6 +1281,9 @@ mod tests {
         ))
     }
 
+    /// Tests that attempting to deserialize a malformed value wrapped in
+    /// multiple layers fails with a nested error with wrapping layers
+    /// corresponding to the layers wrapping the malformed value.
     #[test]
     fn test_deserial_malformed_nested_list_fails() {
         let account_bytes = [0u8; ACCOUNT_ADDRESS_SIZE];
@@ -1341,6 +1359,8 @@ impl From<std::string::FromUtf8Error> for ParseError {
     fn from(_: std::string::FromUtf8Error) -> Self { ParseError::default() }
 }
 
+/// Deserialize a list of values corresponding to the `item_to_json` function
+/// from `source`
 fn item_list_to_json<T: AsRef<[u8]>>(
     source: &mut Cursor<T>,
     size_len: SizeLength,
@@ -1363,6 +1383,7 @@ fn item_list_to_json<T: AsRef<[u8]>>(
     Ok(values)
 }
 
+/// Deserialize a [String] of variable length from `source`.
 fn deserial_string<R: Read>(
     source: &mut R,
     size_len: SizeLength,
@@ -1743,6 +1764,7 @@ impl Type {
     }
 }
 
+/// Deserialize a uleb128 encoded [BigUint] from `source`.
 fn deserial_biguint<R: Read>(source: &mut R, constraint: u32) -> ParseResult<BigUint> {
     let mut result = BigUint::zero();
     let mut shift = 0;
@@ -1759,6 +1781,7 @@ fn deserial_biguint<R: Read>(source: &mut R, constraint: u32) -> ParseResult<Big
     Err(ParseError {})
 }
 
+/// Deserialize a ileb128 encoded [BigInt] from `source`.
 fn deserial_bigint<R: Read>(source: &mut R, constraint: u32) -> ParseResult<BigInt> {
     let mut result = BigInt::zero();
     let mut shift = 0;

--- a/concordium-contracts-common/src/schema_json.rs
+++ b/concordium-contracts-common/src/schema_json.rs
@@ -107,7 +107,7 @@ impl From<Vec<u8>> for ToJsonErrorData {
 
 impl Display for ToJsonErrorData {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.0.iter().map(|b| write!(f, "{:02x?}", b)).collect()
+        self.0.iter().try_for_each(|b| write!(f, "{:02x?}", b))
     }
 }
 
@@ -358,11 +358,9 @@ fn write_bytes_from_json_schema_type<'a, W: Write>(
                 let len = values.len();
                 write_bytes_for_length_of_size(len, size_len, out)?;
 
-                let mut i = 0;
-                for value in values {
+                for (i, value) in values.iter().enumerate() {
                     write_bytes_from_json_schema_type(ty, value, out)
                         .map_err(|e| e.add_trace(format!("{}", i), json))?;
-                    i += 1;
                 }
                 Ok(())
             } else {
@@ -374,11 +372,9 @@ fn write_bytes_from_json_schema_type<'a, W: Write>(
                 let len = values.len();
                 write_bytes_for_length_of_size(len, size_len, out)?;
 
-                let mut i = 0;
-                for value in values {
+                for (i, value) in values.iter().enumerate() {
                     write_bytes_from_json_schema_type(ty, value, out)
                         .map_err(|e| e.add_trace(format!("{}", i), json))?;
-                    i += 1;
                 }
                 Ok(())
             } else {
@@ -390,8 +386,7 @@ fn write_bytes_from_json_schema_type<'a, W: Write>(
                 let len = entries.len();
                 write_bytes_for_length_of_size(len, size_len, out)?;
 
-                let mut i = 0;
-                for entry in entries {
+                for (i, entry) in entries.iter().enumerate() {
                     if let Value::Array(pair) = entry {
                         ensure!(pair.len() == 2, MapError("Expected key-value pair".to_string()));
                         let result: Result<(), JsonError> = {
@@ -402,7 +397,6 @@ fn write_bytes_from_json_schema_type<'a, W: Write>(
                             Ok(())
                         };
                         result.map_err(|e| e.add_trace(format!("{}", i), json))?;
-                        i += 1;
                     } else {
                         return Err(WrongJsonType(
                             "Expected key value pairs as JSON arrays".to_string(),
@@ -425,11 +419,9 @@ fn write_bytes_from_json_schema_type<'a, W: Write>(
                     ))
                 );
 
-                let mut i = 0;
-                for value in values {
+                for (i, value) in values.iter().enumerate() {
                     write_bytes_from_json_schema_type(ty, value, out)
                         .map_err(|e| e.add_trace(format!("{}", i), json))?;
-                    i += 1;
                 }
                 Ok(())
             } else {

--- a/concordium-contracts-common/src/schema_json.rs
+++ b/concordium-contracts-common/src/schema_json.rs
@@ -1,5 +1,4 @@
 use crate::{constants::*, schema::*, *};
-use core::num::TryFromIntError;
 use num_bigint::{BigInt, BigUint};
 use num_traits::Zero;
 use serde_json::Value;
@@ -44,7 +43,7 @@ pub enum JsonError<'a> {
     #[error("{field} -> {error}")]
     TraceError {
         field: String,
-        json: &'a serde_json::Value,
+        json:  &'a serde_json::Value,
         error: Box<JsonError<'a>>,
     },
 }
@@ -74,9 +73,10 @@ impl<'a> JsonError<'a> {
         self
     }
 
-    /// Prints a formatted error message for variant. [JsonError::TraceError] supports printing a
-    /// verbose form including a more detailed description of the error stack, which is returned if
-    /// `verbose` is set to true.
+    /// Prints a formatted error message for variant. [JsonError::TraceError]
+    /// supports printing a verbose form including a more detailed
+    /// description of the error stack, which is returned if `verbose` is
+    /// set to true.
     pub fn print(&self, verbose: bool) -> String {
         match self {
             JsonError::TraceError {
@@ -100,20 +100,20 @@ pub enum ToJsonError<'a> {
     #[error("Failed to deserialize {schema:?} from position {position} of {data:x?}")]
     DeserialError {
         position: u32,
-        schema: Type,
-        data: &'a [u8],
+        schema:   Type,
+        data:     &'a [u8],
     },
     #[error("{schema:?} from {position} -> {error}")]
     TraceError {
         position: u32,
-        schema: Type,
-        error: Box<ToJsonError<'a>>,
+        schema:   Type,
+        error:    Box<ToJsonError<'a>>,
     },
 }
 
 impl<'a> ToJsonError<'a> {
-    /// Wraps a [ToJsonError] in a [ToJsonError::TraceError], providing a trace to
-    /// the origin of the error.
+    /// Wraps a [ToJsonError] in a [ToJsonError::TraceError], providing a trace
+    /// to the origin of the error.
     fn add_trace(self, position: u32, schema: &Type) -> Self {
         ToJsonError::TraceError {
             position,
@@ -122,9 +122,10 @@ impl<'a> ToJsonError<'a> {
         }
     }
 
-    /// Prints a formatted error message for variant. [ToJsonError::TraceError] supports printing a
-    /// verbose form including a more detailed description of the error stack, which is returned if
-    /// `verbose` is set to true.
+    /// Prints a formatted error message for variant. [ToJsonError::TraceError]
+    /// supports printing a verbose form including a more detailed
+    /// description of the error stack, which is returned if `verbose` is
+    /// set to true.
     pub fn print(&self, verbose: bool) -> String {
         match self {
             ToJsonError::TraceError {
@@ -1048,9 +1049,7 @@ impl Fields {
 }
 
 impl From<std::string::FromUtf8Error> for ParseError {
-    fn from(_: std::string::FromUtf8Error) -> Self {
-        ParseError::default()
-    }
+    fn from(_: std::string::FromUtf8Error) -> Self { ParseError::default() }
 }
 
 fn item_list_to_json<'a, T: AsRef<[u8]>>(

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -201,7 +201,9 @@ impl Amount {
 
     /// Get the amount in microCCD
     #[inline(always)]
-    pub const fn micro_ccd(&self) -> u64 { self.micro_ccd }
+    pub const fn micro_ccd(&self) -> u64 {
+        self.micro_ccd
+    }
 
     /// Create amount from a number of CCD
     #[inline(always)]
@@ -339,22 +341,30 @@ impl iter::Sum for Amount {
 
 impl ops::AddAssign for Amount {
     #[inline(always)]
-    fn add_assign(&mut self, other: Amount) { *self = *self + other; }
+    fn add_assign(&mut self, other: Amount) {
+        *self = *self + other;
+    }
 }
 
 impl ops::SubAssign for Amount {
     #[inline(always)]
-    fn sub_assign(&mut self, other: Amount) { *self = *self - other; }
+    fn sub_assign(&mut self, other: Amount) {
+        *self = *self - other;
+    }
 }
 
 impl ops::MulAssign<u64> for Amount {
     #[inline(always)]
-    fn mul_assign(&mut self, other: u64) { *self = *self * other; }
+    fn mul_assign(&mut self, other: u64) {
+        *self = *self * other;
+    }
 }
 
 impl ops::RemAssign<u64> for Amount {
     #[inline(always)]
-    fn rem_assign(&mut self, other: u64) { *self = *self % other; }
+    fn rem_assign(&mut self, other: u64) {
+        *self = *self % other;
+    }
 }
 
 /// The current public balances of an account.
@@ -362,7 +372,7 @@ impl ops::RemAssign<u64> for Amount {
 pub struct AccountBalance {
     /// The total balance of the account. Note that part of this balance might
     /// be staked and/or locked in scheduled transfers.
-    pub total:  Amount,
+    pub total: Amount,
     /// The current staked amount of the account. This amount is used for
     /// staking.
     pub staked: Amount,
@@ -389,7 +399,9 @@ impl AccountBalance {
     /// The current available balance of the account. This is the amount
     /// an account currently has available for transferring and is not
     /// staked or locked in releases by scheduled transfers.
-    pub fn available(&self) -> Amount { self.total - cmp::max(self.locked, self.staked) }
+    pub fn available(&self) -> Amount {
+        self.total - cmp::max(self.locked, self.staked)
+    }
 }
 
 /// Timestamp represented as milliseconds since unix epoch.
@@ -427,7 +439,9 @@ impl Timestamp {
 
     /// Milliseconds since the UNIX epoch.
     #[inline(always)]
-    pub fn timestamp_millis(&self) -> u64 { self.milliseconds }
+    pub fn timestamp_millis(&self) -> u64 {
+        self.milliseconds
+    }
 
     /// Add duration to the timestamp. Returns `None` if the resulting timestamp
     /// is not representable, i.e., too far in the future.
@@ -553,39 +567,57 @@ impl Duration {
 
     /// Construct duration from seconds.
     #[inline(always)]
-    pub const fn from_seconds(seconds: u64) -> Self { Self::from_millis(seconds * 1000) }
+    pub const fn from_seconds(seconds: u64) -> Self {
+        Self::from_millis(seconds * 1000)
+    }
 
     /// Construct duration from minutes.
     #[inline(always)]
-    pub const fn from_minutes(minutes: u64) -> Self { Self::from_millis(minutes * 1000 * 60) }
+    pub const fn from_minutes(minutes: u64) -> Self {
+        Self::from_millis(minutes * 1000 * 60)
+    }
 
     /// Construct duration from hours.
     #[inline(always)]
-    pub const fn from_hours(hours: u64) -> Self { Self::from_millis(hours * 1000 * 60 * 60) }
+    pub const fn from_hours(hours: u64) -> Self {
+        Self::from_millis(hours * 1000 * 60 * 60)
+    }
 
     /// Construct duration from days.
     #[inline(always)]
-    pub const fn from_days(days: u64) -> Self { Self::from_millis(days * 1000 * 60 * 60 * 24) }
+    pub const fn from_days(days: u64) -> Self {
+        Self::from_millis(days * 1000 * 60 * 60 * 24)
+    }
 
     /// Get number of milliseconds in the duration.
     #[inline(always)]
-    pub fn millis(&self) -> u64 { self.milliseconds }
+    pub fn millis(&self) -> u64 {
+        self.milliseconds
+    }
 
     /// Get number of seconds in the duration.
     #[inline(always)]
-    pub fn seconds(&self) -> u64 { self.milliseconds / 1000 }
+    pub fn seconds(&self) -> u64 {
+        self.milliseconds / 1000
+    }
 
     /// Get number of minutes in the duration.
     #[inline(always)]
-    pub fn minutes(&self) -> u64 { self.milliseconds / (1000 * 60) }
+    pub fn minutes(&self) -> u64 {
+        self.milliseconds / (1000 * 60)
+    }
 
     /// Get number of hours in the duration.
     #[inline(always)]
-    pub fn hours(&self) -> u64 { self.milliseconds / (1000 * 60 * 60) }
+    pub fn hours(&self) -> u64 {
+        self.milliseconds / (1000 * 60 * 60)
+    }
 
     /// Get number of days in the duration.
     #[inline(always)]
-    pub fn days(&self) -> u64 { self.milliseconds / (1000 * 60 * 60 * 24) }
+    pub fn days(&self) -> u64 {
+        self.milliseconds / (1000 * 60 * 60 * 24)
+    }
 
     /// Add duration. Returns `None` instead of overflowing.
     #[inline(always)]
@@ -707,22 +739,30 @@ impl quickcheck::Arbitrary for AccountAddress {
 }
 
 impl convert::AsRef<[u8; 32]> for AccountAddress {
-    fn as_ref(&self) -> &[u8; 32] { &self.0 }
+    fn as_ref(&self) -> &[u8; 32] {
+        &self.0
+    }
 }
 
 impl convert::AsRef<[u8]> for AccountAddress {
-    fn as_ref(&self) -> &[u8] { &self.0 }
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
 }
 
 impl convert::AsMut<[u8; 32]> for AccountAddress {
-    fn as_mut(&mut self) -> &mut [u8; 32] { &mut self.0 }
+    fn as_mut(&mut self) -> &mut [u8; 32] {
+        &mut self.0
+    }
 }
 
 impl AccountAddress {
     /// Check whether `self` is an alias of `other`. Two addresses are aliases
     /// if they identify the same account. This is defined to be when the
     /// addresses agree on the first 29 bytes.
-    pub fn is_alias(&self, other: &AccountAddress) -> bool { self.0[0..29] == other.0[0..29] }
+    pub fn is_alias(&self, other: &AccountAddress) -> bool {
+        self.0[0..29] == other.0[0..29]
+    }
 
     /// Get the `n-th` alias of an address. There are 2^24 possible aliases.
     /// If the counter is `>= 2^24` then this function will return [`None`].
@@ -742,7 +782,7 @@ impl AccountAddress {
 #[cfg_attr(feature = "derive-serde", derive(SerdeSerialize, SerdeDeserialize))]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct ContractAddress {
-    pub index:    ContractIndex,
+    pub index: ContractIndex,
     pub subindex: ContractSubIndex,
 }
 
@@ -760,7 +800,7 @@ impl ContractAddress {
 impl quickcheck::Arbitrary for ContractAddress {
     fn arbitrary(g: &mut Gen) -> ContractAddress {
         ContractAddress {
-            index:    quickcheck::Arbitrary::arbitrary(g),
+            index: quickcheck::Arbitrary::arbitrary(g),
             subindex: quickcheck::Arbitrary::arbitrary(g),
         }
     }
@@ -770,7 +810,7 @@ impl quickcheck::Arbitrary for ContractAddress {
         let subindex = self.subindex;
         let iter = index.shrink().flat_map(move |i| {
             subindex.shrink().map(move |si| ContractAddress {
-                index:    i,
+                index: i,
                 subindex: si,
             })
         });
@@ -817,11 +857,15 @@ impl quickcheck::Arbitrary for Address {
 }
 
 impl From<AccountAddress> for Address {
-    fn from(address: AccountAddress) -> Address { Address::Account(address) }
+    fn from(address: AccountAddress) -> Address {
+        Address::Account(address)
+    }
 }
 
 impl From<ContractAddress> for Address {
-    fn from(address: ContractAddress) -> Address { Address::Contract(address) }
+    fn from(address: ContractAddress) -> Address {
+        Address::Contract(address)
+    }
 }
 
 // This trait is implemented manually to produce fewer bytes in the generated
@@ -856,7 +900,9 @@ impl Hash for Address {
 // This trait is implemented manually to produce fewer bytes in the generated
 // WASM.
 impl PartialOrd for Address {
-    fn partial_cmp(&self, other: &Address) -> Option<Ordering> { Some(self.cmp(other)) }
+    fn partial_cmp(&self, other: &Address) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 // This trait is implemented manually to produce fewer bytes in the generated
@@ -878,15 +924,21 @@ pub struct ContractName<'a>(&'a str);
 
 impl<'a> fmt::Display for ContractName<'a> {
     #[inline(always)]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 impl<'a> PartialEq<str> for ContractName<'a> {
-    fn eq(&self, other: &str) -> bool { self.0 == other }
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
 }
 
 impl<'a> PartialEq<&'a str> for ContractName<'a> {
-    fn eq(&self, other: &&'a str) -> bool { self.0 == *other }
+    fn eq(&self, other: &&'a str) -> bool {
+        self.0 == *other
+    }
 }
 
 impl<'a> ContractName<'a> {
@@ -903,19 +955,27 @@ impl<'a> ContractName<'a> {
     /// the behaviour of any methods on this type is unspecified, and may
     /// include panics.
     #[inline(always)]
-    pub fn new_unchecked(name: &'a str) -> Self { ContractName(name) }
+    pub fn new_unchecked(name: &'a str) -> Self {
+        ContractName(name)
+    }
 
     /// Get contract name used on chain: "init_<contract_name>".
     #[inline(always)]
-    pub fn get_chain_name(self) -> &'a str { self.0 }
+    pub fn get_chain_name(self) -> &'a str {
+        self.0
+    }
 
     /// Convert a [`ContractName`] to its owned counterpart. This is an
     /// expensive operation that requires memory allocation.
-    pub fn to_owned(&self) -> OwnedContractName { OwnedContractName(self.0.to_owned()) }
+    pub fn to_owned(&self) -> OwnedContractName {
+        OwnedContractName(self.0.to_owned())
+    }
 
     /// Extract the contract name by removing the "init_" prefix.
     #[inline(always)]
-    pub fn contract_name(self) -> &'a str { self.get_chain_name().strip_prefix("init_").unwrap() }
+    pub fn contract_name(self) -> &'a str {
+        self.get_chain_name().strip_prefix("init_").unwrap()
+    }
 
     /// Check whether the given string is a valid contract initialization
     /// function name. This is the case if and only if
@@ -943,7 +1003,9 @@ impl<'a> ContractName<'a> {
 }
 
 impl<'a> From<ContractName<'a>> for &'a str {
-    fn from(n: ContractName<'a>) -> Self { n.0 }
+    fn from(n: ContractName<'a>) -> Self {
+        n.0
+    }
 }
 
 /// A contract name (owned version). Expected format: "init_<contract_name>".
@@ -957,15 +1019,21 @@ pub struct OwnedContractName(String);
 
 impl fmt::Display for OwnedContractName {
     #[inline(always)]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 impl PartialEq<str> for OwnedContractName {
-    fn eq(&self, other: &str) -> bool { self.0 == other }
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
 }
 
 impl<'a> PartialEq<&'a str> for OwnedContractName {
-    fn eq(&self, other: &&'a str) -> bool { self.0 == *other }
+    fn eq(&self, other: &&'a str) -> bool {
+        self.0 == *other
+    }
 }
 
 impl OwnedContractName {
@@ -980,15 +1048,21 @@ impl OwnedContractName {
     /// Create a new OwnedContractName without checking the format. Expected
     /// format: "init_<contract_name>".
     #[inline(always)]
-    pub fn new_unchecked(name: String) -> Self { OwnedContractName(name) }
+    pub fn new_unchecked(name: String) -> Self {
+        OwnedContractName(name)
+    }
 
     /// Convert to [`ContractName`] by reference.
     #[inline(always)]
-    pub fn as_contract_name(&self) -> ContractName { ContractName(self.0.as_str()) }
+    pub fn as_contract_name(&self) -> ContractName {
+        ContractName(self.0.as_str())
+    }
 }
 
 impl From<OwnedContractName> for String {
-    fn from(n: OwnedContractName) -> Self { n.0 }
+    fn from(n: OwnedContractName) -> Self {
+        n.0
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1022,7 +1096,9 @@ impl std::error::Error for NewContractNameError {}
 impl convert::TryFrom<String> for OwnedContractName {
     type Error = NewContractNameError;
 
-    fn try_from(value: String) -> Result<Self, Self::Error> { OwnedContractName::new(value) }
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        OwnedContractName::new(value)
+    }
 }
 
 /// A receive name. Expected format: "<contract_name>.<func_name>".
@@ -1032,15 +1108,21 @@ pub struct ReceiveName<'a>(&'a str);
 
 impl<'a> fmt::Display for ReceiveName<'a> {
     #[inline(always)]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 impl<'a> PartialEq<str> for ReceiveName<'a> {
-    fn eq(&self, other: &str) -> bool { self.0 == other }
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
 }
 
 impl<'a> PartialEq<&'a str> for ReceiveName<'a> {
-    fn eq(&self, other: &&'a str) -> bool { self.0 == *other }
+    fn eq(&self, other: &&'a str) -> bool {
+        self.0 == *other
+    }
 }
 
 impl<'a> ReceiveName<'a> {
@@ -1054,20 +1136,30 @@ impl<'a> ReceiveName<'a> {
     /// Create a new ReceiveName without checking the format. Expected format:
     /// "<contract_name>.<func_name>".
     #[inline(always)]
-    pub fn new_unchecked(name: &'a str) -> Self { ReceiveName(name) }
+    pub fn new_unchecked(name: &'a str) -> Self {
+        ReceiveName(name)
+    }
 
     /// Get receive name used on chain: "<contract_name>.<func_name>".
-    pub fn get_chain_name(self) -> &'a str { self.0 }
+    pub fn get_chain_name(self) -> &'a str {
+        self.0
+    }
 
     /// Convert a [`ReceiveName`] to its owned counterpart. This is an expensive
     /// operation that requires memory allocation.
-    pub fn to_owned(self) -> OwnedReceiveName { OwnedReceiveName(self.0.to_string()) }
+    pub fn to_owned(self) -> OwnedReceiveName {
+        OwnedReceiveName(self.0.to_string())
+    }
 
     /// Extract the contract name by splitting at the first dot.
-    pub fn contract_name(self) -> &'a str { self.get_name_parts().0 }
+    pub fn contract_name(self) -> &'a str {
+        self.get_name_parts().0
+    }
 
     /// Extract the entrypoint name by splitting at the first dot.
-    pub fn entrypoint_name(self) -> EntrypointName<'a> { EntrypointName(self.get_name_parts().1) }
+    pub fn entrypoint_name(self) -> EntrypointName<'a> {
+        EntrypointName(self.get_name_parts().1)
+    }
 
     /// Extract (contract_name, func_name) by splitting at the first dot.
     fn get_name_parts(self) -> (&'a str, &'a str) {
@@ -1108,30 +1200,40 @@ impl<'a> ReceiveName<'a> {
 pub struct OwnedReceiveName(String);
 
 impl PartialEq<str> for OwnedReceiveName {
-    fn eq(&self, other: &str) -> bool { self.0 == other }
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
 }
 
 impl<'a> PartialEq<&'a str> for OwnedReceiveName {
-    fn eq(&self, other: &&'a str) -> bool { self.0 == *other }
+    fn eq(&self, other: &&'a str) -> bool {
+        self.0 == *other
+    }
 }
 
 impl fmt::Display for OwnedReceiveName {
     #[inline(always)]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 impl convert::TryFrom<String> for OwnedReceiveName {
     type Error = NewReceiveNameError;
 
     #[inline(always)]
-    fn try_from(value: String) -> Result<Self, Self::Error> { OwnedReceiveName::new(value) }
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        OwnedReceiveName::new(value)
+    }
 }
 
 impl str::FromStr for OwnedReceiveName {
     type Err = NewReceiveNameError;
 
     #[inline(always)]
-    fn from_str(s: &str) -> Result<Self, Self::Err> { OwnedReceiveName::new(s.to_string()) }
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        OwnedReceiveName::new(s.to_string())
+    }
 }
 
 impl OwnedReceiveName {
@@ -1165,12 +1267,16 @@ impl OwnedReceiveName {
     /// Create a new OwnedReceiveName without checking the format. Expected
     /// format: "<contract_name>.<func_name>".
     #[inline(always)]
-    pub fn new_unchecked(name: String) -> Self { OwnedReceiveName(name) }
+    pub fn new_unchecked(name: String) -> Self {
+        OwnedReceiveName(name)
+    }
 
     /// Convert to [`ReceiveName`]. See [`ReceiveName`] for additional methods
     /// available on the type.
     #[inline(always)]
-    pub fn as_receive_name(&self) -> ReceiveName { ReceiveName(self.0.as_str()) }
+    pub fn as_receive_name(&self) -> ReceiveName {
+        ReceiveName(self.0.as_str())
+    }
 }
 
 /// An entrypoint name (borrowed version). Expected format:
@@ -1184,7 +1290,9 @@ pub struct EntrypointName<'a>(pub(crate) &'a str);
 
 impl<'a> EntrypointName<'a> {
     /// Size of the name in bytes.
-    pub fn size(&self) -> u32 { self.0.as_bytes().len() as u32 }
+    pub fn size(&self) -> u32 {
+        self.0.as_bytes().len() as u32
+    }
 
     /// Create a new name and check the format. See [is_valid_entrypoint_name]
     /// for the expected format.
@@ -1195,33 +1303,47 @@ impl<'a> EntrypointName<'a> {
 
     /// Convert a [`EntrypointName`] to its owned counterpart. This is an
     /// expensive operation that requires memory allocation.
-    pub fn to_owned(&self) -> OwnedEntrypointName { OwnedEntrypointName(self.0.to_owned()) }
+    pub fn to_owned(&self) -> OwnedEntrypointName {
+        OwnedEntrypointName(self.0.to_owned())
+    }
 
     /// Create a new name. **This does not check the format and is therefore
     /// unsafe.** It is provided for convenience since sometimes it is
     /// statically clear that the format is satisfied.
     #[inline(always)]
-    pub const fn new_unchecked(name: &'a str) -> Self { Self(name) }
+    pub const fn new_unchecked(name: &'a str) -> Self {
+        Self(name)
+    }
 }
 
 impl<'a> fmt::Display for EntrypointName<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str(self.0) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0)
+    }
 }
 
 impl<'a> From<EntrypointName<'a>> for &'a str {
-    fn from(en: EntrypointName<'a>) -> Self { en.0 }
+    fn from(en: EntrypointName<'a>) -> Self {
+        en.0
+    }
 }
 
 impl<'a> From<EntrypointName<'a>> for OwnedEntrypointName {
-    fn from(epn: EntrypointName<'a>) -> Self { Self(String::from(epn.0)) }
+    fn from(epn: EntrypointName<'a>) -> Self {
+        Self(String::from(epn.0))
+    }
 }
 
 impl<'a> PartialEq<str> for EntrypointName<'a> {
-    fn eq(&self, other: &str) -> bool { self.0 == other }
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
 }
 
 impl<'a> PartialEq<&'a str> for EntrypointName<'a> {
-    fn eq(&self, other: &&'a str) -> bool { self.0 == *other }
+    fn eq(&self, other: &&'a str) -> bool {
+        self.0 == *other
+    }
 }
 
 /// An entrypoint name (owned version). Expected format:
@@ -1234,25 +1356,35 @@ impl<'a> PartialEq<&'a str> for EntrypointName<'a> {
 pub struct OwnedEntrypointName(pub(crate) String);
 
 impl fmt::Display for OwnedEntrypointName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.as_entrypoint_name().fmt(f) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_entrypoint_name().fmt(f)
+    }
 }
 
 impl From<OwnedEntrypointName> for String {
-    fn from(oen: OwnedEntrypointName) -> Self { oen.0 }
+    fn from(oen: OwnedEntrypointName) -> Self {
+        oen.0
+    }
 }
 
 impl convert::TryFrom<String> for OwnedEntrypointName {
     type Error = NewReceiveNameError;
 
-    fn try_from(value: String) -> Result<Self, Self::Error> { OwnedEntrypointName::new(value) }
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        OwnedEntrypointName::new(value)
+    }
 }
 
 impl PartialEq<str> for OwnedEntrypointName {
-    fn eq(&self, other: &str) -> bool { self.0 == other }
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
 }
 
 impl<'a> PartialEq<&'a str> for OwnedEntrypointName {
-    fn eq(&self, other: &&'a str) -> bool { self.0 == *other }
+    fn eq(&self, other: &&'a str) -> bool {
+        self.0 == *other
+    }
 }
 
 impl OwnedEntrypointName {
@@ -1267,11 +1399,15 @@ impl OwnedEntrypointName {
     /// unsafe.** It is provided for convenience since sometimes it is
     /// statically clear that the format is satisfied.
     #[inline(always)]
-    pub fn new_unchecked(name: String) -> Self { Self(name) }
+    pub fn new_unchecked(name: String) -> Self {
+        Self(name)
+    }
 
     /// Convert to an [`EntrypointName`] by reference.
     #[inline(always)]
-    pub fn as_entrypoint_name(&self) -> EntrypointName { EntrypointName(self.0.as_str()) }
+    pub fn as_entrypoint_name(&self) -> EntrypointName {
+        EntrypointName(self.0.as_str())
+    }
 }
 
 /// Parameter to the init function or entrypoint.
@@ -1281,7 +1417,9 @@ pub struct Parameter<'a>(pub(crate) &'a [u8]);
 
 impl<'a> AsRef<[u8]> for Parameter<'a> {
     #[inline(always)]
-    fn as_ref(&self) -> &[u8] { self.0 }
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
 }
 
 impl<'a> convert::TryFrom<&'a [u8]> for Parameter<'a> {
@@ -1301,7 +1439,9 @@ impl<'a> convert::TryFrom<&'a [u8]> for Parameter<'a> {
 }
 
 impl<'a> From<Parameter<'a>> for &'a [u8] {
-    fn from(p: Parameter<'a>) -> Self { p.0 }
+    fn from(p: Parameter<'a>) -> Self {
+        p.0
+    }
 }
 
 /// Display the entire parameter in hex.
@@ -1319,11 +1459,15 @@ impl<'a> Parameter<'a> {
     /// fits the size limit. The caller is assumed to ensure this via
     /// external means.
     #[inline]
-    pub fn new_unchecked(bytes: &'a [u8]) -> Self { Self(bytes) }
+    pub fn new_unchecked(bytes: &'a [u8]) -> Self {
+        Self(bytes)
+    }
 
     /// Construct an empty parameter.
     #[inline]
-    pub fn empty() -> Self { Self(&[]) }
+    pub fn empty() -> Self {
+        Self(&[])
+    }
 }
 
 /// Parameter to the init function or entrypoint. Owned version.
@@ -1343,12 +1487,14 @@ pub struct OwnedParameter(
 )]
 pub struct ExceedsParameterSize {
     pub actual: usize,
-    pub max:    usize,
+    pub max: usize,
 }
 
 impl AsRef<[u8]> for OwnedParameter {
     #[inline(always)]
-    fn as_ref(&self) -> &[u8] { self.0.as_ref() }
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
 }
 
 impl convert::TryFrom<Vec<u8>> for OwnedParameter {
@@ -1368,7 +1514,9 @@ impl convert::TryFrom<Vec<u8>> for OwnedParameter {
 }
 
 impl From<OwnedParameter> for Vec<u8> {
-    fn from(op: OwnedParameter) -> Self { op.0 }
+    fn from(op: OwnedParameter) -> Self {
+        op.0
+    }
 }
 
 /// Display the entire parameter in hex.
@@ -1383,7 +1531,9 @@ impl fmt::Display for OwnedParameter {
 
 impl OwnedParameter {
     /// Get [`Self`] as the borrowed variant [`Parameter`].
-    pub fn as_parameter(&self) -> Parameter { Parameter(self.0.as_ref()) }
+    pub fn as_parameter(&self) -> Parameter {
+        Parameter(self.0.as_ref())
+    }
 
     /// Construct an [`Self`]` by serializing the input using its
     /// `Serial` instance.
@@ -1395,7 +1545,7 @@ impl OwnedParameter {
         if bytes.len() > constants::MAX_PARAMETER_LEN {
             return Err(ExceedsParameterSize {
                 actual: bytes.len(),
-                max:    constants::MAX_PARAMETER_LEN,
+                max: constants::MAX_PARAMETER_LEN,
             });
         }
         Ok(Self(bytes))
@@ -1405,11 +1555,15 @@ impl OwnedParameter {
     /// fits the size limit. The caller is assumed to ensure this via
     /// external means.
     #[inline]
-    pub fn new_unchecked(bytes: Vec<u8>) -> Self { Self(bytes) }
+    pub fn new_unchecked(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
 
     /// Construct an empty parameter.
     #[inline]
-    pub fn empty() -> Self { Self(Vec::new()) }
+    pub fn empty() -> Self {
+        Self(Vec::new())
+    }
 }
 
 /// Check whether the given string is a valid contract entrypoint name.
@@ -1468,7 +1622,7 @@ pub type SlotTime = Timestamp;
 )]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExchangeRate {
-    numerator:   u64,
+    numerator: u64,
     denominator: u64,
 }
 
@@ -1499,17 +1653,21 @@ impl ExchangeRate {
     }
 
     /// Get the numerator. This is never 0.
-    pub fn numerator(&self) -> u64 { self.numerator }
+    pub fn numerator(&self) -> u64 {
+        self.numerator
+    }
 
     /// Get the denominator. This is never 0.
-    pub fn denominator(&self) -> u64 { self.denominator }
+    pub fn denominator(&self) -> u64 {
+        self.denominator
+    }
 }
 
 /// The euro/NRG and microCCD/euro exchange rates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExchangeRates {
     /// Euro per NRG exchange rate.
-    pub euro_per_energy:    ExchangeRate,
+    pub euro_per_energy: ExchangeRate,
     /// Micro CCD per Euro exchange rate.
     pub micro_ccd_per_euro: ExchangeRate,
 }
@@ -1570,7 +1728,7 @@ impl quickcheck::Arbitrary for ChainMetadata {
 #[derive(Debug)]
 pub struct Cursor<T> {
     pub offset: usize,
-    pub data:   T,
+    pub data: T,
 }
 
 #[cfg(feature = "std")]
@@ -1608,7 +1766,9 @@ impl quickcheck::Arbitrary for AttributeTag {
     // supports more attributes and it is reasonable to generate all values
     // supported by the protocol to ensure that the tested code is robust with
     // respect to future additions.
-    fn arbitrary(g: &mut Gen) -> AttributeTag { AttributeTag(quickcheck::Arbitrary::arbitrary(g)) }
+    fn arbitrary(g: &mut Gen) -> AttributeTag {
+        AttributeTag(quickcheck::Arbitrary::arbitrary(g))
+    }
 
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
         Box::new(quickcheck::Arbitrary::shrink(&self.0).map(AttributeTag))
@@ -1661,10 +1821,14 @@ impl AttributeValue {
     }
 
     /// Get the length of the attribute value.
-    pub fn len(&self) -> usize { self.inner[0].into() }
+    pub fn len(&self) -> usize {
+        self.inner[0].into()
+    }
 
     /// Whether the attribute value has zero length.
-    pub fn is_empty(&self) -> bool { self.len() == 0 }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 #[cfg(feature = "concordium-quickcheck")]
@@ -1701,13 +1865,17 @@ impl quickcheck::Arbitrary for AttributeValue {
 }
 
 impl AsRef<[u8]> for AttributeValue {
-    fn as_ref(&self) -> &[u8] { &self.inner[1..=usize::from(self.inner[0])] }
+    fn as_ref(&self) -> &[u8] {
+        &self.inner[1..=usize::from(self.inner[0])]
+    }
 }
 
 impl convert::TryFrom<&[u8]> for AttributeValue {
     type Error = NewAttributeValueError;
 
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> { Self::new(value) }
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
 }
 
 /// Apply the given macro to each of the elements in the list
@@ -1732,11 +1900,15 @@ macro_rules! repeat_macro {
 macro_rules! from_bytearray_to_attribute_value {
     ($n:expr) => {
         impl From<[u8; $n]> for AttributeValue {
-            fn from(data: [u8; $n]) -> Self { AttributeValue::new(&data[..]).unwrap() }
+            fn from(data: [u8; $n]) -> Self {
+                AttributeValue::new(&data[..]).unwrap()
+            }
         }
 
         impl From<&[u8; $n]> for AttributeValue {
-            fn from(data: &[u8; $n]) -> Self { AttributeValue::new(&data[..]).unwrap() }
+            fn from(data: &[u8; $n]) -> Self {
+                AttributeValue::new(&data[..]).unwrap()
+            }
         }
     };
 }
@@ -1834,11 +2006,11 @@ pub struct Policy<Attributes> {
     /// they have created with accounts that users created on the chain.
     /// as a timestamp (which has millisecond granularity) in order to make it
     /// easier to compare with, e.g., `slot_time`.
-    pub created_at:        Timestamp,
+    pub created_at: Timestamp,
     /// Beginning of the month where the identity is __no longer valid__.
-    pub valid_to:          Timestamp,
+    pub valid_to: Timestamp,
     /// List of attributes, in ascending order of the tag.
-    pub items:             Attributes,
+    pub items: Attributes,
 }
 
 /// Generate a vector of random key-value pairs with no duplication
@@ -1916,9 +2088,9 @@ impl quickcheck::Arbitrary for OwnedPolicy {
                     valid_to.shrink().flat_map(move |vt| {
                         items.shrink().map(move |it| OwnedPolicy {
                             identity_provider: ip,
-                            created_at:        ca,
-                            valid_to:          vt,
-                            items:             it,
+                            created_at: ca,
+                            valid_to: vt,
+                            items: it,
                         })
                     })
                 })
@@ -1934,7 +2106,8 @@ impl quickcheck::Arbitrary for OwnedPolicy {
 impl<'de> SerdeDeserialize<'de> for OwnedPolicy {
     fn deserialize<D>(deserializer: D) -> Result<OwnedPolicy, D::Error>
     where
-        D: serde::Deserializer<'de>, {
+        D: serde::Deserializer<'de>,
+    {
         deserializer.deserialize_map(policy_json::OwnedPolicyVisitor)
     }
 }
@@ -2118,7 +2291,7 @@ pub mod attributes {
 ///     // ...
 /// }
 /// ```
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 pub struct ParseError {}
 
 /// A type alias used to indicate that the value is a result
@@ -2126,7 +2299,9 @@ pub struct ParseError {}
 pub type ParseResult<A> = Result<A, ParseError>;
 
 impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str("Parsing failed") }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Parsing failed")
+    }
 }
 
 #[cfg(feature = "std")]
@@ -2169,7 +2344,7 @@ mod serde_impl {
                 mantissa.try_into().map_err(|_| ExchangeRateConversionError::Unrepresentable)?;
             let g = num_integer::gcd(numerator, denominator);
             Ok(ExchangeRate {
-                numerator:   numerator / g,
+                numerator: numerator / g,
                 denominator: denominator / g,
             })
         }
@@ -2181,7 +2356,7 @@ mod serde_impl {
         String(String),
         Num(f64),
         Object {
-            numerator:   u64,
+            numerator: u64,
             denominator: u64,
         },
     }
@@ -2199,7 +2374,7 @@ mod serde_impl {
                 } => {
                     let g = num_integer::gcd(numerator, denominator);
                     Ok(ExchangeRate {
-                        numerator:   numerator / g,
+                        numerator: numerator / g,
                         denominator: denominator / g,
                     })
                 }
@@ -2279,7 +2454,8 @@ mod serde_impl {
 
                 fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
                 where
-                    E: serde::de::Error, {
+                    E: serde::de::Error,
+                {
                     let r = hex::decode(v).map_err(serde::de::Error::custom)?;
                     Ok(r)
                 }
@@ -2487,7 +2663,7 @@ mod serde_impl {
         #[test]
         fn test_exchange_rate_json() {
             let data = ExchangeRate {
-                numerator:   1,
+                numerator: 1,
                 denominator: 100,
             };
             assert_eq!(
@@ -2501,12 +2677,12 @@ mod serde_impl {
                 "Exchange rate: case 2"
             );
             let data2 = ExchangeRate {
-                numerator:   10,
+                numerator: 10,
                 denominator: 1,
             };
             assert_eq!(data2, serde_json::from_str("10").unwrap(), "Exchange rate: case 3");
             let data3 = ExchangeRate {
-                numerator:   17,
+                numerator: 17,
                 denominator: 39,
             };
             assert_eq!(

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -201,9 +201,7 @@ impl Amount {
 
     /// Get the amount in microCCD
     #[inline(always)]
-    pub const fn micro_ccd(&self) -> u64 {
-        self.micro_ccd
-    }
+    pub const fn micro_ccd(&self) -> u64 { self.micro_ccd }
 
     /// Create amount from a number of CCD
     #[inline(always)]
@@ -341,30 +339,22 @@ impl iter::Sum for Amount {
 
 impl ops::AddAssign for Amount {
     #[inline(always)]
-    fn add_assign(&mut self, other: Amount) {
-        *self = *self + other;
-    }
+    fn add_assign(&mut self, other: Amount) { *self = *self + other; }
 }
 
 impl ops::SubAssign for Amount {
     #[inline(always)]
-    fn sub_assign(&mut self, other: Amount) {
-        *self = *self - other;
-    }
+    fn sub_assign(&mut self, other: Amount) { *self = *self - other; }
 }
 
 impl ops::MulAssign<u64> for Amount {
     #[inline(always)]
-    fn mul_assign(&mut self, other: u64) {
-        *self = *self * other;
-    }
+    fn mul_assign(&mut self, other: u64) { *self = *self * other; }
 }
 
 impl ops::RemAssign<u64> for Amount {
     #[inline(always)]
-    fn rem_assign(&mut self, other: u64) {
-        *self = *self % other;
-    }
+    fn rem_assign(&mut self, other: u64) { *self = *self % other; }
 }
 
 /// The current public balances of an account.
@@ -372,7 +362,7 @@ impl ops::RemAssign<u64> for Amount {
 pub struct AccountBalance {
     /// The total balance of the account. Note that part of this balance might
     /// be staked and/or locked in scheduled transfers.
-    pub total: Amount,
+    pub total:  Amount,
     /// The current staked amount of the account. This amount is used for
     /// staking.
     pub staked: Amount,
@@ -399,9 +389,7 @@ impl AccountBalance {
     /// The current available balance of the account. This is the amount
     /// an account currently has available for transferring and is not
     /// staked or locked in releases by scheduled transfers.
-    pub fn available(&self) -> Amount {
-        self.total - cmp::max(self.locked, self.staked)
-    }
+    pub fn available(&self) -> Amount { self.total - cmp::max(self.locked, self.staked) }
 }
 
 /// Timestamp represented as milliseconds since unix epoch.
@@ -439,9 +427,7 @@ impl Timestamp {
 
     /// Milliseconds since the UNIX epoch.
     #[inline(always)]
-    pub fn timestamp_millis(&self) -> u64 {
-        self.milliseconds
-    }
+    pub fn timestamp_millis(&self) -> u64 { self.milliseconds }
 
     /// Add duration to the timestamp. Returns `None` if the resulting timestamp
     /// is not representable, i.e., too far in the future.
@@ -567,57 +553,39 @@ impl Duration {
 
     /// Construct duration from seconds.
     #[inline(always)]
-    pub const fn from_seconds(seconds: u64) -> Self {
-        Self::from_millis(seconds * 1000)
-    }
+    pub const fn from_seconds(seconds: u64) -> Self { Self::from_millis(seconds * 1000) }
 
     /// Construct duration from minutes.
     #[inline(always)]
-    pub const fn from_minutes(minutes: u64) -> Self {
-        Self::from_millis(minutes * 1000 * 60)
-    }
+    pub const fn from_minutes(minutes: u64) -> Self { Self::from_millis(minutes * 1000 * 60) }
 
     /// Construct duration from hours.
     #[inline(always)]
-    pub const fn from_hours(hours: u64) -> Self {
-        Self::from_millis(hours * 1000 * 60 * 60)
-    }
+    pub const fn from_hours(hours: u64) -> Self { Self::from_millis(hours * 1000 * 60 * 60) }
 
     /// Construct duration from days.
     #[inline(always)]
-    pub const fn from_days(days: u64) -> Self {
-        Self::from_millis(days * 1000 * 60 * 60 * 24)
-    }
+    pub const fn from_days(days: u64) -> Self { Self::from_millis(days * 1000 * 60 * 60 * 24) }
 
     /// Get number of milliseconds in the duration.
     #[inline(always)]
-    pub fn millis(&self) -> u64 {
-        self.milliseconds
-    }
+    pub fn millis(&self) -> u64 { self.milliseconds }
 
     /// Get number of seconds in the duration.
     #[inline(always)]
-    pub fn seconds(&self) -> u64 {
-        self.milliseconds / 1000
-    }
+    pub fn seconds(&self) -> u64 { self.milliseconds / 1000 }
 
     /// Get number of minutes in the duration.
     #[inline(always)]
-    pub fn minutes(&self) -> u64 {
-        self.milliseconds / (1000 * 60)
-    }
+    pub fn minutes(&self) -> u64 { self.milliseconds / (1000 * 60) }
 
     /// Get number of hours in the duration.
     #[inline(always)]
-    pub fn hours(&self) -> u64 {
-        self.milliseconds / (1000 * 60 * 60)
-    }
+    pub fn hours(&self) -> u64 { self.milliseconds / (1000 * 60 * 60) }
 
     /// Get number of days in the duration.
     #[inline(always)]
-    pub fn days(&self) -> u64 {
-        self.milliseconds / (1000 * 60 * 60 * 24)
-    }
+    pub fn days(&self) -> u64 { self.milliseconds / (1000 * 60 * 60 * 24) }
 
     /// Add duration. Returns `None` instead of overflowing.
     #[inline(always)]
@@ -739,30 +707,22 @@ impl quickcheck::Arbitrary for AccountAddress {
 }
 
 impl convert::AsRef<[u8; 32]> for AccountAddress {
-    fn as_ref(&self) -> &[u8; 32] {
-        &self.0
-    }
+    fn as_ref(&self) -> &[u8; 32] { &self.0 }
 }
 
 impl convert::AsRef<[u8]> for AccountAddress {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
+    fn as_ref(&self) -> &[u8] { &self.0 }
 }
 
 impl convert::AsMut<[u8; 32]> for AccountAddress {
-    fn as_mut(&mut self) -> &mut [u8; 32] {
-        &mut self.0
-    }
+    fn as_mut(&mut self) -> &mut [u8; 32] { &mut self.0 }
 }
 
 impl AccountAddress {
     /// Check whether `self` is an alias of `other`. Two addresses are aliases
     /// if they identify the same account. This is defined to be when the
     /// addresses agree on the first 29 bytes.
-    pub fn is_alias(&self, other: &AccountAddress) -> bool {
-        self.0[0..29] == other.0[0..29]
-    }
+    pub fn is_alias(&self, other: &AccountAddress) -> bool { self.0[0..29] == other.0[0..29] }
 
     /// Get the `n-th` alias of an address. There are 2^24 possible aliases.
     /// If the counter is `>= 2^24` then this function will return [`None`].
@@ -782,7 +742,7 @@ impl AccountAddress {
 #[cfg_attr(feature = "derive-serde", derive(SerdeSerialize, SerdeDeserialize))]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct ContractAddress {
-    pub index: ContractIndex,
+    pub index:    ContractIndex,
     pub subindex: ContractSubIndex,
 }
 
@@ -800,7 +760,7 @@ impl ContractAddress {
 impl quickcheck::Arbitrary for ContractAddress {
     fn arbitrary(g: &mut Gen) -> ContractAddress {
         ContractAddress {
-            index: quickcheck::Arbitrary::arbitrary(g),
+            index:    quickcheck::Arbitrary::arbitrary(g),
             subindex: quickcheck::Arbitrary::arbitrary(g),
         }
     }
@@ -810,7 +770,7 @@ impl quickcheck::Arbitrary for ContractAddress {
         let subindex = self.subindex;
         let iter = index.shrink().flat_map(move |i| {
             subindex.shrink().map(move |si| ContractAddress {
-                index: i,
+                index:    i,
                 subindex: si,
             })
         });
@@ -857,15 +817,11 @@ impl quickcheck::Arbitrary for Address {
 }
 
 impl From<AccountAddress> for Address {
-    fn from(address: AccountAddress) -> Address {
-        Address::Account(address)
-    }
+    fn from(address: AccountAddress) -> Address { Address::Account(address) }
 }
 
 impl From<ContractAddress> for Address {
-    fn from(address: ContractAddress) -> Address {
-        Address::Contract(address)
-    }
+    fn from(address: ContractAddress) -> Address { Address::Contract(address) }
 }
 
 // This trait is implemented manually to produce fewer bytes in the generated
@@ -900,9 +856,7 @@ impl Hash for Address {
 // This trait is implemented manually to produce fewer bytes in the generated
 // WASM.
 impl PartialOrd for Address {
-    fn partial_cmp(&self, other: &Address) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
+    fn partial_cmp(&self, other: &Address) -> Option<Ordering> { Some(self.cmp(other)) }
 }
 
 // This trait is implemented manually to produce fewer bytes in the generated
@@ -924,21 +878,15 @@ pub struct ContractName<'a>(&'a str);
 
 impl<'a> fmt::Display for ContractName<'a> {
     #[inline(always)]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
 }
 
 impl<'a> PartialEq<str> for ContractName<'a> {
-    fn eq(&self, other: &str) -> bool {
-        self.0 == other
-    }
+    fn eq(&self, other: &str) -> bool { self.0 == other }
 }
 
 impl<'a> PartialEq<&'a str> for ContractName<'a> {
-    fn eq(&self, other: &&'a str) -> bool {
-        self.0 == *other
-    }
+    fn eq(&self, other: &&'a str) -> bool { self.0 == *other }
 }
 
 impl<'a> ContractName<'a> {
@@ -955,27 +903,19 @@ impl<'a> ContractName<'a> {
     /// the behaviour of any methods on this type is unspecified, and may
     /// include panics.
     #[inline(always)]
-    pub fn new_unchecked(name: &'a str) -> Self {
-        ContractName(name)
-    }
+    pub fn new_unchecked(name: &'a str) -> Self { ContractName(name) }
 
     /// Get contract name used on chain: "init_<contract_name>".
     #[inline(always)]
-    pub fn get_chain_name(self) -> &'a str {
-        self.0
-    }
+    pub fn get_chain_name(self) -> &'a str { self.0 }
 
     /// Convert a [`ContractName`] to its owned counterpart. This is an
     /// expensive operation that requires memory allocation.
-    pub fn to_owned(&self) -> OwnedContractName {
-        OwnedContractName(self.0.to_owned())
-    }
+    pub fn to_owned(&self) -> OwnedContractName { OwnedContractName(self.0.to_owned()) }
 
     /// Extract the contract name by removing the "init_" prefix.
     #[inline(always)]
-    pub fn contract_name(self) -> &'a str {
-        self.get_chain_name().strip_prefix("init_").unwrap()
-    }
+    pub fn contract_name(self) -> &'a str { self.get_chain_name().strip_prefix("init_").unwrap() }
 
     /// Check whether the given string is a valid contract initialization
     /// function name. This is the case if and only if
@@ -1003,9 +943,7 @@ impl<'a> ContractName<'a> {
 }
 
 impl<'a> From<ContractName<'a>> for &'a str {
-    fn from(n: ContractName<'a>) -> Self {
-        n.0
-    }
+    fn from(n: ContractName<'a>) -> Self { n.0 }
 }
 
 /// A contract name (owned version). Expected format: "init_<contract_name>".
@@ -1019,21 +957,15 @@ pub struct OwnedContractName(String);
 
 impl fmt::Display for OwnedContractName {
     #[inline(always)]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
 }
 
 impl PartialEq<str> for OwnedContractName {
-    fn eq(&self, other: &str) -> bool {
-        self.0 == other
-    }
+    fn eq(&self, other: &str) -> bool { self.0 == other }
 }
 
 impl<'a> PartialEq<&'a str> for OwnedContractName {
-    fn eq(&self, other: &&'a str) -> bool {
-        self.0 == *other
-    }
+    fn eq(&self, other: &&'a str) -> bool { self.0 == *other }
 }
 
 impl OwnedContractName {
@@ -1048,21 +980,15 @@ impl OwnedContractName {
     /// Create a new OwnedContractName without checking the format. Expected
     /// format: "init_<contract_name>".
     #[inline(always)]
-    pub fn new_unchecked(name: String) -> Self {
-        OwnedContractName(name)
-    }
+    pub fn new_unchecked(name: String) -> Self { OwnedContractName(name) }
 
     /// Convert to [`ContractName`] by reference.
     #[inline(always)]
-    pub fn as_contract_name(&self) -> ContractName {
-        ContractName(self.0.as_str())
-    }
+    pub fn as_contract_name(&self) -> ContractName { ContractName(self.0.as_str()) }
 }
 
 impl From<OwnedContractName> for String {
-    fn from(n: OwnedContractName) -> Self {
-        n.0
-    }
+    fn from(n: OwnedContractName) -> Self { n.0 }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1096,9 +1022,7 @@ impl std::error::Error for NewContractNameError {}
 impl convert::TryFrom<String> for OwnedContractName {
     type Error = NewContractNameError;
 
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        OwnedContractName::new(value)
-    }
+    fn try_from(value: String) -> Result<Self, Self::Error> { OwnedContractName::new(value) }
 }
 
 /// A receive name. Expected format: "<contract_name>.<func_name>".
@@ -1108,21 +1032,15 @@ pub struct ReceiveName<'a>(&'a str);
 
 impl<'a> fmt::Display for ReceiveName<'a> {
     #[inline(always)]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
 }
 
 impl<'a> PartialEq<str> for ReceiveName<'a> {
-    fn eq(&self, other: &str) -> bool {
-        self.0 == other
-    }
+    fn eq(&self, other: &str) -> bool { self.0 == other }
 }
 
 impl<'a> PartialEq<&'a str> for ReceiveName<'a> {
-    fn eq(&self, other: &&'a str) -> bool {
-        self.0 == *other
-    }
+    fn eq(&self, other: &&'a str) -> bool { self.0 == *other }
 }
 
 impl<'a> ReceiveName<'a> {
@@ -1136,30 +1054,20 @@ impl<'a> ReceiveName<'a> {
     /// Create a new ReceiveName without checking the format. Expected format:
     /// "<contract_name>.<func_name>".
     #[inline(always)]
-    pub fn new_unchecked(name: &'a str) -> Self {
-        ReceiveName(name)
-    }
+    pub fn new_unchecked(name: &'a str) -> Self { ReceiveName(name) }
 
     /// Get receive name used on chain: "<contract_name>.<func_name>".
-    pub fn get_chain_name(self) -> &'a str {
-        self.0
-    }
+    pub fn get_chain_name(self) -> &'a str { self.0 }
 
     /// Convert a [`ReceiveName`] to its owned counterpart. This is an expensive
     /// operation that requires memory allocation.
-    pub fn to_owned(self) -> OwnedReceiveName {
-        OwnedReceiveName(self.0.to_string())
-    }
+    pub fn to_owned(self) -> OwnedReceiveName { OwnedReceiveName(self.0.to_string()) }
 
     /// Extract the contract name by splitting at the first dot.
-    pub fn contract_name(self) -> &'a str {
-        self.get_name_parts().0
-    }
+    pub fn contract_name(self) -> &'a str { self.get_name_parts().0 }
 
     /// Extract the entrypoint name by splitting at the first dot.
-    pub fn entrypoint_name(self) -> EntrypointName<'a> {
-        EntrypointName(self.get_name_parts().1)
-    }
+    pub fn entrypoint_name(self) -> EntrypointName<'a> { EntrypointName(self.get_name_parts().1) }
 
     /// Extract (contract_name, func_name) by splitting at the first dot.
     fn get_name_parts(self) -> (&'a str, &'a str) {
@@ -1200,40 +1108,30 @@ impl<'a> ReceiveName<'a> {
 pub struct OwnedReceiveName(String);
 
 impl PartialEq<str> for OwnedReceiveName {
-    fn eq(&self, other: &str) -> bool {
-        self.0 == other
-    }
+    fn eq(&self, other: &str) -> bool { self.0 == other }
 }
 
 impl<'a> PartialEq<&'a str> for OwnedReceiveName {
-    fn eq(&self, other: &&'a str) -> bool {
-        self.0 == *other
-    }
+    fn eq(&self, other: &&'a str) -> bool { self.0 == *other }
 }
 
 impl fmt::Display for OwnedReceiveName {
     #[inline(always)]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
 }
 
 impl convert::TryFrom<String> for OwnedReceiveName {
     type Error = NewReceiveNameError;
 
     #[inline(always)]
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        OwnedReceiveName::new(value)
-    }
+    fn try_from(value: String) -> Result<Self, Self::Error> { OwnedReceiveName::new(value) }
 }
 
 impl str::FromStr for OwnedReceiveName {
     type Err = NewReceiveNameError;
 
     #[inline(always)]
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        OwnedReceiveName::new(s.to_string())
-    }
+    fn from_str(s: &str) -> Result<Self, Self::Err> { OwnedReceiveName::new(s.to_string()) }
 }
 
 impl OwnedReceiveName {
@@ -1267,16 +1165,12 @@ impl OwnedReceiveName {
     /// Create a new OwnedReceiveName without checking the format. Expected
     /// format: "<contract_name>.<func_name>".
     #[inline(always)]
-    pub fn new_unchecked(name: String) -> Self {
-        OwnedReceiveName(name)
-    }
+    pub fn new_unchecked(name: String) -> Self { OwnedReceiveName(name) }
 
     /// Convert to [`ReceiveName`]. See [`ReceiveName`] for additional methods
     /// available on the type.
     #[inline(always)]
-    pub fn as_receive_name(&self) -> ReceiveName {
-        ReceiveName(self.0.as_str())
-    }
+    pub fn as_receive_name(&self) -> ReceiveName { ReceiveName(self.0.as_str()) }
 }
 
 /// An entrypoint name (borrowed version). Expected format:
@@ -1290,9 +1184,7 @@ pub struct EntrypointName<'a>(pub(crate) &'a str);
 
 impl<'a> EntrypointName<'a> {
     /// Size of the name in bytes.
-    pub fn size(&self) -> u32 {
-        self.0.as_bytes().len() as u32
-    }
+    pub fn size(&self) -> u32 { self.0.as_bytes().len() as u32 }
 
     /// Create a new name and check the format. See [is_valid_entrypoint_name]
     /// for the expected format.
@@ -1303,47 +1195,33 @@ impl<'a> EntrypointName<'a> {
 
     /// Convert a [`EntrypointName`] to its owned counterpart. This is an
     /// expensive operation that requires memory allocation.
-    pub fn to_owned(&self) -> OwnedEntrypointName {
-        OwnedEntrypointName(self.0.to_owned())
-    }
+    pub fn to_owned(&self) -> OwnedEntrypointName { OwnedEntrypointName(self.0.to_owned()) }
 
     /// Create a new name. **This does not check the format and is therefore
     /// unsafe.** It is provided for convenience since sometimes it is
     /// statically clear that the format is satisfied.
     #[inline(always)]
-    pub const fn new_unchecked(name: &'a str) -> Self {
-        Self(name)
-    }
+    pub const fn new_unchecked(name: &'a str) -> Self { Self(name) }
 }
 
 impl<'a> fmt::Display for EntrypointName<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.0)
-    }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str(self.0) }
 }
 
 impl<'a> From<EntrypointName<'a>> for &'a str {
-    fn from(en: EntrypointName<'a>) -> Self {
-        en.0
-    }
+    fn from(en: EntrypointName<'a>) -> Self { en.0 }
 }
 
 impl<'a> From<EntrypointName<'a>> for OwnedEntrypointName {
-    fn from(epn: EntrypointName<'a>) -> Self {
-        Self(String::from(epn.0))
-    }
+    fn from(epn: EntrypointName<'a>) -> Self { Self(String::from(epn.0)) }
 }
 
 impl<'a> PartialEq<str> for EntrypointName<'a> {
-    fn eq(&self, other: &str) -> bool {
-        self.0 == other
-    }
+    fn eq(&self, other: &str) -> bool { self.0 == other }
 }
 
 impl<'a> PartialEq<&'a str> for EntrypointName<'a> {
-    fn eq(&self, other: &&'a str) -> bool {
-        self.0 == *other
-    }
+    fn eq(&self, other: &&'a str) -> bool { self.0 == *other }
 }
 
 /// An entrypoint name (owned version). Expected format:
@@ -1356,35 +1234,25 @@ impl<'a> PartialEq<&'a str> for EntrypointName<'a> {
 pub struct OwnedEntrypointName(pub(crate) String);
 
 impl fmt::Display for OwnedEntrypointName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.as_entrypoint_name().fmt(f)
-    }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.as_entrypoint_name().fmt(f) }
 }
 
 impl From<OwnedEntrypointName> for String {
-    fn from(oen: OwnedEntrypointName) -> Self {
-        oen.0
-    }
+    fn from(oen: OwnedEntrypointName) -> Self { oen.0 }
 }
 
 impl convert::TryFrom<String> for OwnedEntrypointName {
     type Error = NewReceiveNameError;
 
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        OwnedEntrypointName::new(value)
-    }
+    fn try_from(value: String) -> Result<Self, Self::Error> { OwnedEntrypointName::new(value) }
 }
 
 impl PartialEq<str> for OwnedEntrypointName {
-    fn eq(&self, other: &str) -> bool {
-        self.0 == other
-    }
+    fn eq(&self, other: &str) -> bool { self.0 == other }
 }
 
 impl<'a> PartialEq<&'a str> for OwnedEntrypointName {
-    fn eq(&self, other: &&'a str) -> bool {
-        self.0 == *other
-    }
+    fn eq(&self, other: &&'a str) -> bool { self.0 == *other }
 }
 
 impl OwnedEntrypointName {
@@ -1399,15 +1267,11 @@ impl OwnedEntrypointName {
     /// unsafe.** It is provided for convenience since sometimes it is
     /// statically clear that the format is satisfied.
     #[inline(always)]
-    pub fn new_unchecked(name: String) -> Self {
-        Self(name)
-    }
+    pub fn new_unchecked(name: String) -> Self { Self(name) }
 
     /// Convert to an [`EntrypointName`] by reference.
     #[inline(always)]
-    pub fn as_entrypoint_name(&self) -> EntrypointName {
-        EntrypointName(self.0.as_str())
-    }
+    pub fn as_entrypoint_name(&self) -> EntrypointName { EntrypointName(self.0.as_str()) }
 }
 
 /// Parameter to the init function or entrypoint.
@@ -1417,9 +1281,7 @@ pub struct Parameter<'a>(pub(crate) &'a [u8]);
 
 impl<'a> AsRef<[u8]> for Parameter<'a> {
     #[inline(always)]
-    fn as_ref(&self) -> &[u8] {
-        self.0
-    }
+    fn as_ref(&self) -> &[u8] { self.0 }
 }
 
 impl<'a> convert::TryFrom<&'a [u8]> for Parameter<'a> {
@@ -1439,9 +1301,7 @@ impl<'a> convert::TryFrom<&'a [u8]> for Parameter<'a> {
 }
 
 impl<'a> From<Parameter<'a>> for &'a [u8] {
-    fn from(p: Parameter<'a>) -> Self {
-        p.0
-    }
+    fn from(p: Parameter<'a>) -> Self { p.0 }
 }
 
 /// Display the entire parameter in hex.
@@ -1459,15 +1319,11 @@ impl<'a> Parameter<'a> {
     /// fits the size limit. The caller is assumed to ensure this via
     /// external means.
     #[inline]
-    pub fn new_unchecked(bytes: &'a [u8]) -> Self {
-        Self(bytes)
-    }
+    pub fn new_unchecked(bytes: &'a [u8]) -> Self { Self(bytes) }
 
     /// Construct an empty parameter.
     #[inline]
-    pub fn empty() -> Self {
-        Self(&[])
-    }
+    pub fn empty() -> Self { Self(&[]) }
 }
 
 /// Parameter to the init function or entrypoint. Owned version.
@@ -1487,14 +1343,12 @@ pub struct OwnedParameter(
 )]
 pub struct ExceedsParameterSize {
     pub actual: usize,
-    pub max: usize,
+    pub max:    usize,
 }
 
 impl AsRef<[u8]> for OwnedParameter {
     #[inline(always)]
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
+    fn as_ref(&self) -> &[u8] { self.0.as_ref() }
 }
 
 impl convert::TryFrom<Vec<u8>> for OwnedParameter {
@@ -1514,9 +1368,7 @@ impl convert::TryFrom<Vec<u8>> for OwnedParameter {
 }
 
 impl From<OwnedParameter> for Vec<u8> {
-    fn from(op: OwnedParameter) -> Self {
-        op.0
-    }
+    fn from(op: OwnedParameter) -> Self { op.0 }
 }
 
 /// Display the entire parameter in hex.
@@ -1531,9 +1383,7 @@ impl fmt::Display for OwnedParameter {
 
 impl OwnedParameter {
     /// Get [`Self`] as the borrowed variant [`Parameter`].
-    pub fn as_parameter(&self) -> Parameter {
-        Parameter(self.0.as_ref())
-    }
+    pub fn as_parameter(&self) -> Parameter { Parameter(self.0.as_ref()) }
 
     /// Construct an [`Self`]` by serializing the input using its
     /// `Serial` instance.
@@ -1545,7 +1395,7 @@ impl OwnedParameter {
         if bytes.len() > constants::MAX_PARAMETER_LEN {
             return Err(ExceedsParameterSize {
                 actual: bytes.len(),
-                max: constants::MAX_PARAMETER_LEN,
+                max:    constants::MAX_PARAMETER_LEN,
             });
         }
         Ok(Self(bytes))
@@ -1555,15 +1405,11 @@ impl OwnedParameter {
     /// fits the size limit. The caller is assumed to ensure this via
     /// external means.
     #[inline]
-    pub fn new_unchecked(bytes: Vec<u8>) -> Self {
-        Self(bytes)
-    }
+    pub fn new_unchecked(bytes: Vec<u8>) -> Self { Self(bytes) }
 
     /// Construct an empty parameter.
     #[inline]
-    pub fn empty() -> Self {
-        Self(Vec::new())
-    }
+    pub fn empty() -> Self { Self(Vec::new()) }
 }
 
 /// Check whether the given string is a valid contract entrypoint name.
@@ -1622,7 +1468,7 @@ pub type SlotTime = Timestamp;
 )]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExchangeRate {
-    numerator: u64,
+    numerator:   u64,
     denominator: u64,
 }
 
@@ -1653,21 +1499,17 @@ impl ExchangeRate {
     }
 
     /// Get the numerator. This is never 0.
-    pub fn numerator(&self) -> u64 {
-        self.numerator
-    }
+    pub fn numerator(&self) -> u64 { self.numerator }
 
     /// Get the denominator. This is never 0.
-    pub fn denominator(&self) -> u64 {
-        self.denominator
-    }
+    pub fn denominator(&self) -> u64 { self.denominator }
 }
 
 /// The euro/NRG and microCCD/euro exchange rates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExchangeRates {
     /// Euro per NRG exchange rate.
-    pub euro_per_energy: ExchangeRate,
+    pub euro_per_energy:    ExchangeRate,
     /// Micro CCD per Euro exchange rate.
     pub micro_ccd_per_euro: ExchangeRate,
 }
@@ -1728,7 +1570,7 @@ impl quickcheck::Arbitrary for ChainMetadata {
 #[derive(Debug)]
 pub struct Cursor<T> {
     pub offset: usize,
-    pub data: T,
+    pub data:   T,
 }
 
 #[cfg(feature = "std")]
@@ -1766,9 +1608,7 @@ impl quickcheck::Arbitrary for AttributeTag {
     // supports more attributes and it is reasonable to generate all values
     // supported by the protocol to ensure that the tested code is robust with
     // respect to future additions.
-    fn arbitrary(g: &mut Gen) -> AttributeTag {
-        AttributeTag(quickcheck::Arbitrary::arbitrary(g))
-    }
+    fn arbitrary(g: &mut Gen) -> AttributeTag { AttributeTag(quickcheck::Arbitrary::arbitrary(g)) }
 
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
         Box::new(quickcheck::Arbitrary::shrink(&self.0).map(AttributeTag))
@@ -1821,14 +1661,10 @@ impl AttributeValue {
     }
 
     /// Get the length of the attribute value.
-    pub fn len(&self) -> usize {
-        self.inner[0].into()
-    }
+    pub fn len(&self) -> usize { self.inner[0].into() }
 
     /// Whether the attribute value has zero length.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
+    pub fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 #[cfg(feature = "concordium-quickcheck")]
@@ -1865,17 +1701,13 @@ impl quickcheck::Arbitrary for AttributeValue {
 }
 
 impl AsRef<[u8]> for AttributeValue {
-    fn as_ref(&self) -> &[u8] {
-        &self.inner[1..=usize::from(self.inner[0])]
-    }
+    fn as_ref(&self) -> &[u8] { &self.inner[1..=usize::from(self.inner[0])] }
 }
 
 impl convert::TryFrom<&[u8]> for AttributeValue {
     type Error = NewAttributeValueError;
 
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Self::new(value)
-    }
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> { Self::new(value) }
 }
 
 /// Apply the given macro to each of the elements in the list
@@ -1900,15 +1732,11 @@ macro_rules! repeat_macro {
 macro_rules! from_bytearray_to_attribute_value {
     ($n:expr) => {
         impl From<[u8; $n]> for AttributeValue {
-            fn from(data: [u8; $n]) -> Self {
-                AttributeValue::new(&data[..]).unwrap()
-            }
+            fn from(data: [u8; $n]) -> Self { AttributeValue::new(&data[..]).unwrap() }
         }
 
         impl From<&[u8; $n]> for AttributeValue {
-            fn from(data: &[u8; $n]) -> Self {
-                AttributeValue::new(&data[..]).unwrap()
-            }
+            fn from(data: &[u8; $n]) -> Self { AttributeValue::new(&data[..]).unwrap() }
         }
     };
 }
@@ -2006,11 +1834,11 @@ pub struct Policy<Attributes> {
     /// they have created with accounts that users created on the chain.
     /// as a timestamp (which has millisecond granularity) in order to make it
     /// easier to compare with, e.g., `slot_time`.
-    pub created_at: Timestamp,
+    pub created_at:        Timestamp,
     /// Beginning of the month where the identity is __no longer valid__.
-    pub valid_to: Timestamp,
+    pub valid_to:          Timestamp,
     /// List of attributes, in ascending order of the tag.
-    pub items: Attributes,
+    pub items:             Attributes,
 }
 
 /// Generate a vector of random key-value pairs with no duplication
@@ -2088,9 +1916,9 @@ impl quickcheck::Arbitrary for OwnedPolicy {
                     valid_to.shrink().flat_map(move |vt| {
                         items.shrink().map(move |it| OwnedPolicy {
                             identity_provider: ip,
-                            created_at: ca,
-                            valid_to: vt,
-                            items: it,
+                            created_at:        ca,
+                            valid_to:          vt,
+                            items:             it,
                         })
                     })
                 })
@@ -2106,8 +1934,7 @@ impl quickcheck::Arbitrary for OwnedPolicy {
 impl<'de> SerdeDeserialize<'de> for OwnedPolicy {
     fn deserialize<D>(deserializer: D) -> Result<OwnedPolicy, D::Error>
     where
-        D: serde::Deserializer<'de>,
-    {
+        D: serde::Deserializer<'de>, {
         deserializer.deserialize_map(policy_json::OwnedPolicyVisitor)
     }
 }
@@ -2299,9 +2126,7 @@ pub struct ParseError {}
 pub type ParseResult<A> = Result<A, ParseError>;
 
 impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("Parsing failed")
-    }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str("Parsing failed") }
 }
 
 #[cfg(feature = "std")]
@@ -2344,7 +2169,7 @@ mod serde_impl {
                 mantissa.try_into().map_err(|_| ExchangeRateConversionError::Unrepresentable)?;
             let g = num_integer::gcd(numerator, denominator);
             Ok(ExchangeRate {
-                numerator: numerator / g,
+                numerator:   numerator / g,
                 denominator: denominator / g,
             })
         }
@@ -2356,7 +2181,7 @@ mod serde_impl {
         String(String),
         Num(f64),
         Object {
-            numerator: u64,
+            numerator:   u64,
             denominator: u64,
         },
     }
@@ -2374,7 +2199,7 @@ mod serde_impl {
                 } => {
                     let g = num_integer::gcd(numerator, denominator);
                     Ok(ExchangeRate {
-                        numerator: numerator / g,
+                        numerator:   numerator / g,
                         denominator: denominator / g,
                     })
                 }
@@ -2454,8 +2279,7 @@ mod serde_impl {
 
                 fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
                 where
-                    E: serde::de::Error,
-                {
+                    E: serde::de::Error, {
                     let r = hex::decode(v).map_err(serde::de::Error::custom)?;
                     Ok(r)
                 }
@@ -2663,7 +2487,7 @@ mod serde_impl {
         #[test]
         fn test_exchange_rate_json() {
             let data = ExchangeRate {
-                numerator: 1,
+                numerator:   1,
                 denominator: 100,
             };
             assert_eq!(
@@ -2677,12 +2501,12 @@ mod serde_impl {
                 "Exchange rate: case 2"
             );
             let data2 = ExchangeRate {
-                numerator: 10,
+                numerator:   10,
                 denominator: 1,
             };
             assert_eq!(data2, serde_json::from_str("10").unwrap(), "Exchange rate: case 3");
             let data3 = ExchangeRate {
-                numerator: 17,
+                numerator:   17,
                 denominator: 39,
             };
             assert_eq!(

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -2118,7 +2118,7 @@ pub mod attributes {
 ///     // ...
 /// }
 /// ```
-#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct ParseError {}
 
 /// A type alias used to indicate that the value is a result


### PR DESCRIPTION
## Purpose

Adds trace information for errors happening when (de)serializing using contract schemas. I added a few unit tests, mostly to test the format of the trace errors for both `JsonError` and `ToJsonError` are as expected, however they are nowhere exhaustive (If we need more, let me know).

## Changes

- Adds `JsonError::TraceError`, which holds information about the path to the original `JsonError` produced when serializing from schema type
- Adds `ToJsonError` type, which is now the error type returned when deserializing to schema type.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
