### PR TITLE
Bound for type parameters

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -122,4 +122,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all
+          args: --workspace

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -105,7 +105,7 @@ jobs:
           args: --manifest-path=concordium-contracts-common-derive/Cargo.toml --target=${{ matrix.target }} --no-default-features -- -D warnings
 
   test:
-    name: x86_64 tests on concordium-contracts-common
+    name: x86_64 tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -122,4 +122,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=concordium-contracts-common/Cargo.toml
+          args: --all

--- a/concordium-contracts-common-derive/CHANGELOG.md
+++ b/concordium-contracts-common-derive/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Set minimum Rust version to 1.65.
 - Add derive macros for `Reject`, `DeserialWithState`, `SchemaType`, `StateClone` and `Deletable` from `concordium_std_derive`.
 - Add attribute macros `init`, `receive`, `concordium_test`, `concordium_cfg_test`, `concordium_cfg_not_test` and `concordium_quickcheck` from `concordium_std_derive` with their related features `wasm-test`, `build-schema` and `concordium-quickcheck`.
+- Deriving `Serial`, `Deserial`, `DeserialWithState` and `SchemaType` now produces an implementation which adds a bound to each of the type parameters to implement the relevant trait.
+  Note that `Serial` and `DeserialWithState` skips this bound for `state_parameter` when/if this is provided. This is not the behavior of `Deserial` and `SchemaType` since they are incompatible with `DeserialWithState` and therefore `state_parameter` is never present in these cases.
+- Deriving `SchemaType` will now produce an implementation even without the `build-schema` feature being enabled.
 
 ## concordium-contracts-common-derive 2.0.0 (2023-05-08)
 

--- a/concordium-contracts-common-derive/src/lib.rs
+++ b/concordium-contracts-common-derive/src/lib.rs
@@ -63,15 +63,22 @@ pub fn deserial_derive(input: TokenStream) -> TokenStream {
 /// By default a trait bound is added on each generic type for implementing
 /// [`Serial`]. However, if this is not desirable, the bound can be put
 /// explicitly using the `bound` attribute on the type overriding the default
-/// behavior.
+/// behavior by adding the provided bound for the implementation.
+///
+/// Bounds present in the type declaration will still be present in
+/// the implementation, even when a bound is provided:
 ///
 /// ### Example
+///
 /// ```ignore
 /// #[derive(Serial)]
 /// #[concordium(bound(serial = "A: SomeOtherTrait"))]
-/// struct Foo<A> {
+/// struct Foo<A: SomeTrait> {
 ///     bar: A,
 /// }
+///
+/// // Derived implementation:
+/// impl <A: SomeTrait> Serial for Foo<A> where A: SomeOtherTrait { .. }
 /// ```
 ///
 /// ## Collections
@@ -82,7 +89,7 @@ pub fn deserial_derive(input: TokenStream) -> TokenStream {
 /// can be annotated with `size_length`.
 ///
 /// The value of this field is the number of bytes that will be used for
-/// encoding the number of elements. Supported values are `1,` `2,` `4,` `8`.
+/// encoding the number of elements. Supported values are `1`, `2`, `4`, `8`.
 ///
 /// For BTreeMap and BTreeSet the serialize method will serialize values in
 /// increasing order of keys.

--- a/concordium-contracts-common-derive/src/lib.rs
+++ b/concordium-contracts-common-derive/src/lib.rs
@@ -44,23 +44,11 @@ pub fn deserial_derive(input: TokenStream) -> TokenStream {
     unwrap_or_report(derive::impl_deserial(&ast))
 }
 
-/// Derive the Serial trait for the type.
+/// Derive the [`Serial`] trait for the type.
 ///
-/// If the type is a struct all fields must implement the Serial trait. If the
-/// type is an enum then all fields of each of the enums must implement the
-/// Serial trait.
-///
-///
-/// Collections (Vec, BTreeMap, BTreeSet) and strings (String, str) are by
-/// default serialized by prepending the number of elements as 4 bytes
-/// little-endian. If this is too much or too little, fields of the above types
-/// can be annotated with `size_length`.
-///
-/// The value of this field is the number of bytes that will be used for
-/// encoding the number of elements. Supported values are 1, 2, 4, 8.
-///
-/// For BTreeMap and BTreeSet the serialize method will serialize values in
-/// increasing order of keys.
+/// If the type is a struct all fields must implement the [`Serial`] trait. If
+/// the type is an enum then all fields of each of the enums must implement the
+/// [`Serial`] trait.
 ///
 /// Fields of structs are serialized in the order they appear in the code.
 ///
@@ -70,7 +58,36 @@ pub fn deserial_derive(input: TokenStream) -> TokenStream {
 /// single byte is used to encode it. Otherwise two bytes are used for the tag,
 /// encoded in little endian.
 ///
-/// # Example
+/// ## Generic type bounds
+///
+/// By default a trait bound is added on each generic type for implementing
+/// [`Serial`]. However, if this is not desirable, the bound can be put
+/// explicitly using the `bound` attribute on the type overriding the default
+/// behavior.
+///
+/// ### Example
+/// ```ignore
+/// #[derive(Serial)]
+/// #[concordium(bound(serial = "A: SomeOtherTrait"))]
+/// struct Foo<A> {
+///     bar: A,
+/// }
+/// ```
+///
+/// ## Collections
+///
+/// Collections (Vec, BTreeMap, BTreeSet) and strings (String, str) are by
+/// default serialized by prepending the number of elements as 4 bytes
+/// little-endian. If this is too much or too little, fields of the above types
+/// can be annotated with `size_length`.
+///
+/// The value of this field is the number of bytes that will be used for
+/// encoding the number of elements. Supported values are `1,` `2,` `4,` `8`.
+///
+/// For BTreeMap and BTreeSet the serialize method will serialize values in
+/// increasing order of keys.
+///
+/// ### Example
 /// ```ignore
 /// #[derive(Serial)]
 /// struct Foo {


### PR DESCRIPTION
## Purpose

Related to https://github.com/Concordium/concordium-rust-smart-contracts/issues/283.
Tests are implemented in https://github.com/Concordium/concordium-rust-smart-contracts/pull/293.

## Changes

- Deriving `Serial`, `Deserial`, `DeserialWithState` and `SchemaType` now produces an implementation which adds a bound to each of the type parameters to implement the relevant trait.
  Note that `Serial` and `DeserialWithState` skips this bound for `state_parameter` when/if this is provided. This is not the behavior of `Deserial` and `SchemaType` since they are incompatible with `DeserialWithState` and therefore `state_parameter` is never present in these cases.
- Deriving `SchemaType` will now produce code even without the `build-schema` feature being enabled. This PR depends on it to avoid having to introduce separate types (like for `ContainerAttributes`) for when this feature is enabled.

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
