### PR TITLE
Produce proper error for field attributes when deriving Deserial

### DIFF
--- a/concordium-contracts-common-derive/CHANGELOG.md
+++ b/concordium-contracts-common-derive/CHANGELOG.md
@@ -9,6 +9,7 @@
   Note that `Serial` and `DeserialWithState` skips this bound for `state_parameter` when/if this is provided. This is not the behavior of `Deserial` and `SchemaType` since they are incompatible with `DeserialWithState` and therefore `state_parameter` is never present in these cases.
 - Deriving `SchemaType` will now produce an implementation even without the `build-schema` feature being enabled.
 - Support adding attribute `#[concordium(transparent)]` to newtype structs causing a derived `SchemaType` to use the implementation of the single field and thereby hiding the newtype struct in the schema.
+- Fix error message for deriving `Deserial` and `DeserialWithState`, for types with an invalid field attribute.
 
 ## concordium-contracts-common-derive 2.0.0 (2023-05-08)
 

--- a/concordium-contracts-common-derive/src/derive.rs
+++ b/concordium-contracts-common-derive/src/derive.rs
@@ -440,7 +440,7 @@ pub fn impl_deserial(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
                             field,
                             &field_ident,
                             &source_ident,
-                        ));
+                        )?);
                         names.extend(quote!(#field_ident,))
                     }
                     quote!(Ok(#data_name{#names}))
@@ -448,7 +448,7 @@ pub fn impl_deserial(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
                 syn::Fields::Unnamed(_) => {
                     for (i, f) in data.fields.iter().enumerate() {
                         let field_ident = format_ident!("x_{}", i);
-                        field_tokens.extend(impl_deserial_field(f, &field_ident, &source_ident));
+                        field_tokens.extend(impl_deserial_field(f, &field_ident, &source_ident)?);
                         names.extend(quote!(#field_ident,))
                     }
                     quote!(Ok(#data_name(#names)))
@@ -806,7 +806,7 @@ pub fn impl_deserial_with_state(ast: &syn::DeriveInput) -> syn::Result<TokenStre
                             &field_ident,
                             &source_ident,
                             state_parameter,
-                        ));
+                        )?);
                         names.extend(quote!(#field_ident,))
                     }
                     quote!(Ok(#data_name{#names}))
@@ -820,7 +820,7 @@ pub fn impl_deserial_with_state(ast: &syn::DeriveInput) -> syn::Result<TokenStre
                             &field_ident,
                             &source_ident,
                             state_parameter,
-                        ));
+                        )?);
                         names.extend(quote!(#field_ident,))
                     }
                     quote!(Ok(#data_name(#names)))


### PR DESCRIPTION
## Purpose

Fix error when users provide an invalid field attribute.

Currently, when deriving `Deserial` or `DeserialWithState` for a struct with an invalid field attribute such `#[concordium(size_length = "2")]`, where this is expected to be a number literal.

Expected:
![image](https://github.com/Concordium/concordium-contracts-common/assets/6437768/53296816-7bf9-4937-b422-0c1a1d42f649)

Actual:
![image](https://github.com/Concordium/concordium-contracts-common/assets/6437768/29d4f77b-34c5-491d-9d9c-46a1739ba8d0)
