### PR TITLE
Add `tag` and `repr` attribute for deriving serialization

### DIFF
--- a/concordium-contracts-common-derive/CHANGELOG.md
+++ b/concordium-contracts-common-derive/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- Support adding `#[concordium(repr(u))]` for enum types, where `u` is either `u8` or `u16`. Setting this changes the integer serialization used for the variant tags in derive macros such as  `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`.
+- Support adding `#[concordium(tag = n)]` for enum variants, where `n` is some unsigned integer literal. Setting this attribute on a variant overrides the tag used in derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`. Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
+
 ## concordium-contracts-common-derive 3.0.0 (2023-06-16)
 
 - Set minimum Rust version to 1.65.
@@ -12,8 +15,6 @@
 - Deriving `SchemaType` will now produce an implementation even without the `build-schema` feature being enabled.
 - Support adding attribute `#[concordium(transparent)]` to newtype structs causing a derived `SchemaType` to use the implementation of the single field and thereby hiding the newtype struct in the schema.
 - Fix error message for deriving `Deserial` and `DeserialWithState`, for types with an invalid field attribute.
-- Support adding `#[concordium(repr(u))]` for enum types, where `u` is either `u8` or `u16`. Setting this changes the integer serialization used for the variant tags in derive macros such as  `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`.
-- Support adding `#[concordium(tag = n)]` for enum variants, where `n` is some unsigned integer literal. Setting this attribute on a variant overrides the tag used in derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`. Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
 
 ## concordium-contracts-common-derive 2.0.0 (2023-05-08)
 

--- a/concordium-contracts-common-derive/CHANGELOG.md
+++ b/concordium-contracts-common-derive/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Deriving `SchemaType` will now produce an implementation even without the `build-schema` feature being enabled.
 - Support adding attribute `#[concordium(transparent)]` to newtype structs causing a derived `SchemaType` to use the implementation of the single field and thereby hiding the newtype struct in the schema.
 - Fix error message for deriving `Deserial` and `DeserialWithState`, for types with an invalid field attribute.
+- Support adding `#[concordium(repr(u))]` for enum types, where `u` is either `u8` or `u16`. Setting this changes the integer serialization used for the variant tags in derive macros such as  `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`.
+- Support adding `#[concordium(tag = n)]` for enum variants, where `n` is some integer literal. Setting this attribute on a variant overrides the tag used in derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`. Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
 
 ## concordium-contracts-common-derive 2.0.0 (2023-05-08)
 

--- a/concordium-contracts-common-derive/CHANGELOG.md
+++ b/concordium-contracts-common-derive/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Support adding attribute `#[concordium(transparent)]` to newtype structs causing a derived `SchemaType` to use the implementation of the single field and thereby hiding the newtype struct in the schema.
 - Fix error message for deriving `Deserial` and `DeserialWithState`, for types with an invalid field attribute.
 - Support adding `#[concordium(repr(u))]` for enum types, where `u` is either `u8` or `u16`. Setting this changes the integer serialization used for the variant tags in derive macros such as  `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`.
-- Support adding `#[concordium(tag = n)]` for enum variants, where `n` is some integer literal. Setting this attribute on a variant overrides the tag used in derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`. Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
+- Support adding `#[concordium(tag = n)]` for enum variants, where `n` is some unsigned integer literal. Setting this attribute on a variant overrides the tag used in derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`. Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
 
 ## concordium-contracts-common-derive 2.0.0 (2023-05-08)
 

--- a/concordium-contracts-common-derive/src/lib.rs
+++ b/concordium-contracts-common-derive/src/lib.rs
@@ -52,11 +52,53 @@ pub fn deserial_derive(input: TokenStream) -> TokenStream {
 ///
 /// Fields of structs are serialized in the order they appear in the code.
 ///
+/// ## Enums
+///
 /// Enums can have no more than 65536 variants. They are serialized by using a
-/// tag to indicate the variant, enumerating them in the order they are written
-/// in source code. If the number of variants is less than or equal 256 then a
-/// single byte is used to encode it. Otherwise two bytes are used for the tag,
-/// encoded in little endian.
+/// tag to indicate the variant, and by default they are enumerated in the order
+/// they are written in source code. If the number of variants is less than or
+/// equal 256 then a single byte is used to encode it. Otherwise two bytes are
+/// used for the tag, encoded in little endian.
+///
+/// ### Specifying the tag byte size using `#[concordium(repr(..))]`
+///
+/// Optionally an enum type can be annotated with a `#[concordium(repr(x))]`
+/// attribute, where `x` is either `u8` or `u16`. This specifies the number of
+/// bytes to use when serializing the tag in little endian.
+///
+/// #### Example
+///
+/// Example of an enum which uses two bytes for encoding the tag.
+///
+/// ```ignore
+/// #[derive(Serial)]
+/// #[concordium(repr(u16))]
+/// enum MyEnum {
+///     Zero,
+///     One
+/// }
+/// ```
+///
+/// ### Specifying the tag value for a variant using `#[concordium(tag = ..)]`
+///
+/// For each enum variant the tag can be explicitly set using `#[concordium(tag
+/// = n)]` where `n` is the integer literal to use for the tag.
+/// When using the 'tag' attribute it is required to have the
+/// #[concordium(repr(..))] set as well.
+///
+/// #### Example
+///
+/// Example of enum specifying the tag of the variant `Zero` to the value `42`.
+///
+/// ```ignore
+/// #[derive(Serial)]
+/// #[concordium(repr(u8))]
+/// enum MyEnum {
+///     #[concordium(tag = 42)]
+///     Zero,
+///     One
+/// }
+/// ```
 ///
 /// ## Generic type bounds
 ///

--- a/concordium-contracts-common-derive/src/lib.rs
+++ b/concordium-contracts-common-derive/src/lib.rs
@@ -218,11 +218,11 @@ pub fn deserial_with_state_derive(input: TokenStream) -> TokenStream {
 ///
 /// When deriving `Serial`, `Deserial` and `DeserialWithState` the
 /// discriminating tag can be set explicitly using `#[concordium(tag = n)]`
-/// where `n` is a unsigned integer literal and annotating the enum with
-/// `#[concordium(repr(..))]`, see [`Serial`] for more on this attribute. The
-/// current version of the contract schema cannot express tags encoded with more
-/// than one byte, meaning only the annotation of `#[concordium(repr(u8))]` can
-/// be used, when deriving the `SchemaType`.
+/// where `n` is a unsigned integer literal. This require annotating the enum
+/// with `#[concordium(repr(..))]`, see [`Serial`] for more on this attribute.
+/// The current version of the contract schema cannot express tags encoded with
+/// more than one byte, meaning only the annotation of `#[concordium(repr(u8))]`
+/// can be used, when deriving the `SchemaType`.
 ///
 /// ## Generic type bounds
 ///

--- a/concordium-contracts-common-derive/src/lib.rs
+++ b/concordium-contracts-common-derive/src/lib.rs
@@ -56,26 +56,30 @@ pub fn deserial_derive(input: TokenStream) -> TokenStream {
 ///
 /// Enums can have no more than 65536 variants. They are serialized by using a
 /// tag to indicate the variant, and by default they are enumerated in the order
-/// they are written in source code. If the number of variants is less than or
-/// equal 256 then a single byte is used to encode it. Otherwise two bytes are
-/// used for the tag, encoded in little endian.
+/// they are written in the source code. If the number of variants is less than
+/// or to equal 256 then a single byte is used to encode it. Otherwise two bytes
+/// are used for the tag, encoded in little endian.
 ///
 /// ### Specifying the tag byte size using `#[concordium(repr(..))]`
 ///
-/// Optionally an enum type can be annotated with a `#[concordium(repr(x))]`
+/// Optionally, an enum type can be annotated with a `#[concordium(repr(x))]`
 /// attribute, where `x` is either `u8` or `u16`. This specifies the number of
 /// bytes to use when serializing the tag in little endian.
 ///
+/// A type annotated with `#[concordium(repr(u8))]` can only have up to 256
+/// variants and `#[concordium(repr(u16))]` can have up to 65536 variants.
+///
 /// #### Example
 ///
-/// Example of an enum which uses two bytes for encoding the tag.
+/// Example of an enum which uses two bytes for encoding the tag. Here the
+/// variant `A` is tagged using `0u16` and `B` is tagged using `1u16`.
 ///
 /// ```ignore
 /// #[derive(Serial)]
 /// #[concordium(repr(u16))]
 /// enum MyEnum {
-///     Zero,
-///     One
+///     A,
+///     B
 /// }
 /// ```
 ///
@@ -84,19 +88,24 @@ pub fn deserial_derive(input: TokenStream) -> TokenStream {
 /// For each enum variant the tag can be explicitly set using `#[concordium(tag
 /// = n)]` where `n` is the integer literal to use for the tag.
 /// When using the 'tag' attribute it is required to have the
-/// #[concordium(repr(..))] set as well.
+/// `#[concordium(repr(..))]` set as well. The tag must have a value
+/// representable by the type set by `#[concordium(repr(..))]`.
+///
+/// <i>Note that `SchemaType` currently only supports using a single byte
+/// `#([concordium(repr(u8))]`) when using `#[concordium(tag = ..)]`.</i>
 ///
 /// #### Example
 ///
-/// Example of enum specifying the tag of the variant `Zero` to the value `42`.
+/// Example of enum specifying the tag of the variant `A` to the value `42u8`.
+/// The variant `B` is tagged using `1u8`.
 ///
 /// ```ignore
 /// #[derive(Serial)]
 /// #[concordium(repr(u8))]
 /// enum MyEnum {
 ///     #[concordium(tag = 42)]
-///     Zero,
-///     One
+///     A,
+///     B
 /// }
 /// ```
 ///
@@ -204,6 +213,16 @@ pub fn deserial_with_state_derive(input: TokenStream) -> TokenStream {
 /// If the type is a struct all fields must implement the [`SchemaType`] trait.
 /// If the type is an enum then all fields of each of the variants must
 /// implement the [`SchemaType`] trait.
+///
+/// ## Specifying the tag value for an enum variant
+///
+/// When deriving `Serial`, `Deserial` and `DeserialWithState` the
+/// discriminating tag can be set explicitly using `#[concordium(tag = n)]`
+/// where `n` is a unsigned integer literal and annotating the enum with
+/// `#[concordium(repr(..))]`, see [`Serial`] for more on this attribute. The
+/// current version of the contract schema cannot express tags encoded with more
+/// than one byte, meaning only the annotation of `#[concordium(repr(u8))]` can
+/// be used, when deriving the `SchemaType`.
 ///
 /// ## Generic type bounds
 ///


### PR DESCRIPTION
## Purpose

Related to https://github.com/Concordium/concordium-rust-smart-contracts/issues/299
Should be merged before https://github.com/Concordium/concordium-rust-smart-contracts/pull/301.

## Changes

- Support variant attribute `tag` and container attribute `repr`.
- Add `ensure` and `bail` macros internally to increase readability (similar to the ones from `anyhow`).

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

