### PR TITLE
Update syn to version 2 for derive crate

### DIFF
--- a/concordium-contracts-common-derive/Cargo.toml
+++ b/concordium-contracts-common-derive/Cargo.toml
@@ -20,6 +20,6 @@ build-schema = []
 concordium-quickcheck = []
 
 [dependencies]
-syn = { version = "1.0", features = [ "full", "extra-traits" ] }
+syn = { version = "2.0", features = [ "full", "extra-traits" ] }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/concordium-contracts-common/Cargo.toml
+++ b/concordium-contracts-common/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-arbitrary = { version = "0.4", features = ["derive"], optional = true }
+arbitrary = { version = "1.3", features = ["derive"], optional = true }
 base64 = "0.21"
 getrandom = { version = "0.2", features = ["custom"], optional = true }
 quickcheck = { version = "1.0.3", optional = true }
@@ -89,7 +89,7 @@ smart-contract = []
 crate-type = ["rlib"]
 
 [dev-dependencies]
-arbitrary = { version = "0.4", features = ["derive"] }
+arbitrary = { version = "1.3", features = ["derive"] }
 rand = "=0.7"
 rand_pcg = "0.2.1"
 

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1648,7 +1648,7 @@ pub struct AttributeValue {
 }
 
 #[cfg(feature = "fuzz")]
-impl arbitrary::Arbitrary for AttributeValue {
+impl arbitrary::Arbitrary<'_> for AttributeValue {
     fn arbitrary(u: &mut arbitrary::Unstructured) -> arbitrary::Result<Self> {
         let size = u.int_in_range(0..=31)?;
         let mut inner: [u8; 32] = [0u8; 32];


### PR DESCRIPTION
## Purpose

A new version of the syn crate has been released with better support for the Rust syntax and a number of helpers that we would want.
This PR updates the dependency and migrates our code. Not changes for the user.

Should be merged with https://github.com/Concordium/concordium-base/pull/402

