### PR TITLE
Adds function to parse VersionedModuleSchema from base64

### DIFF
--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased changes
 
 - Add `Display` trait to `SchemaType` to display the `SchemaType` as a JSON template
+- Add associated function `from_base64_str` to `VersionedModuleSchema` to easily parse from base64
 
 ## concordium-contracts-common 7.0.0 (2023-06-16)
 

--- a/concordium-contracts-common/Cargo.toml
+++ b/concordium-contracts-common/Cargo.toml
@@ -14,6 +14,7 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 arbitrary = { version = "0.4", features = ["derive"], optional = true }
+base64 = "0.21"
 getrandom = { version = "0.2", features = ["custom"], optional = true }
 quickcheck = { version = "1.0.3", optional = true }
 

--- a/concordium-contracts-common/src/schema.rs
+++ b/concordium-contracts-common/src/schema.rs
@@ -8,6 +8,7 @@ use crate::{impls::*, traits::*, types::*};
 use alloc::boxed::Box;
 #[cfg(not(feature = "std"))]
 use alloc::{collections, string::String, vec::Vec};
+use base64::{engine::general_purpose, Engine};
 use collections::{BTreeMap, BTreeSet};
 #[cfg(not(feature = "std"))]
 use core::{
@@ -1119,6 +1120,16 @@ mod impls {
                 },
             };
             Ok(versioned_module_schema)
+        }
+
+        /// Get a versioned module schema from a base64 string.
+        pub fn from_base64_str(s: &str) -> Result<Self, VersionedSchemaError> {
+            let bytes: Vec<u8> = general_purpose::STANDARD_NO_PAD
+                .decode(s)
+                .map_err(|_| VersionedSchemaError::ParseError)?;
+            let mut cursor = Cursor::new(bytes);
+            let schema = VersionedModuleSchema::deserial(&mut cursor)?;
+            Ok(schema)
         }
 
         /// Returns a receive function's parameter schema from a versioned

--- a/concordium-contracts-common/src/schema.rs
+++ b/concordium-contracts-common/src/schema.rs
@@ -8,6 +8,7 @@ use crate::{impls::*, traits::*, types::*};
 use alloc::boxed::Box;
 #[cfg(not(feature = "std"))]
 use alloc::{collections, string::String, vec::Vec};
+#[allow(unused_imports)]
 use base64::{engine::general_purpose, Engine};
 use collections::{BTreeMap, BTreeSet};
 #[cfg(not(feature = "std"))]

--- a/concordium-contracts-common/src/schema.rs
+++ b/concordium-contracts-common/src/schema.rs
@@ -8,8 +8,6 @@ use crate::{impls::*, traits::*, types::*};
 use alloc::boxed::Box;
 #[cfg(not(feature = "std"))]
 use alloc::{collections, string::String, vec::Vec};
-#[allow(unused_imports)]
-use base64::{engine::general_purpose, Engine};
 use collections::{BTreeMap, BTreeSet};
 #[cfg(not(feature = "std"))]
 use core::{
@@ -1014,6 +1012,7 @@ pub fn deserial_length(source: &mut impl Read, size_len: SizeLength) -> ParseRes
 #[cfg(feature = "derive-serde")]
 mod impls {
     use crate::{from_bytes, schema::*};
+    use base64::{engine::general_purpose, Engine};
 
     /// Useful for get_versioned_contract_schema(), but it's not currently used
     /// as input or output to any function, so it isn't public.


### PR DESCRIPTION
## Purpose

Needed this for the custom indexer epic, thought it could be useful elsewhere as well.

## Changes

- Add `from_base64_str` to `VersionedModuleSchema`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
