### PR TITLE
Derive forward attribute

### DIFF
--- a/concordium-contracts-common-derive/CHANGELOG.md
+++ b/concordium-contracts-common-derive/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - Support adding `#[concordium(repr(u))]` for enum types, where `u` is either `u8` or `u16`. Setting this changes the integer serialization used for the variant tags in derive macros such as  `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`.
 - Support adding `#[concordium(tag = n)]` for enum variants, where `n` is some unsigned integer literal. Setting this attribute on a variant overrides the tag used in derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`. Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
-- Support adding `#[concordium(forward = n)]`, for enum variants, where `n` is either an unsigned integer literal, `cis2_events`, `cis3_events`, `cis4_events` or an array of the same options. Setting this attribute on a variant overrides the (de)serialization to flatten with the (de)serialization of the inner field when  using derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`. Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
+- Support adding `#[concordium(forward = n)]`, for enum variants, where `n` is either an unsigned integer literal, `cis2_events`, `cis3_events`, `cis4_events` or an array of the same options.
+  Setting this attribute on a variant overrides the (de)serialization to flatten with the (de)serialization of the inner field when using derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`.
+  Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
 
 ## concordium-contracts-common-derive 3.0.0 (2023-06-16)
 

--- a/concordium-contracts-common-derive/CHANGELOG.md
+++ b/concordium-contracts-common-derive/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Support adding `#[concordium(repr(u))]` for enum types, where `u` is either `u8` or `u16`. Setting this changes the integer serialization used for the variant tags in derive macros such as  `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`.
 - Support adding `#[concordium(tag = n)]` for enum variants, where `n` is some unsigned integer literal. Setting this attribute on a variant overrides the tag used in derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`. Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
+- Support adding `#[concordium(forward = n)]`, for enum variants, where `n` is either an unsigned integer literal, `cis2_events`, `cis3_events`, `cis4_events` or an array of the same options. Setting this attribute on a variant overrides the (de)serialization to flatten with the (de)serialization of the inner field when  using derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`. Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
 
 ## concordium-contracts-common-derive 3.0.0 (2023-06-16)
 

--- a/concordium-contracts-common-derive/src/derive.rs
+++ b/concordium-contracts-common-derive/src/derive.rs
@@ -415,16 +415,16 @@ impl ContainerAttributes {
             );
         };
 
-        for forward in forward_attributes {
-            for value in &forward.values {
-                for tag in value.get_literals() {
-                    let value: usize = tag.base10_parse()?;
+        for forward_attribute in forward_attributes {
+            for forward_value in &forward_attribute.values {
+                for tag_literal in forward_value.get_literals() {
+                    let value: usize = tag_literal.base10_parse()?;
                     check!(
                         value <= repr.max_tag_value(),
-                        tag.span(),
+                        tag_literal.span(),
                         "'forward' attribute tag value of {} cannot be represented by the type \
                          {1} set in 'repr({1})'",
-                        tag,
+                        tag_literal,
                         repr.ident()
                     );
                 }
@@ -937,7 +937,7 @@ impl TryFrom<&syn::Meta> for ForwardAttribute {
         let syn::Meta::NameValue(name_value) = meta else {
             abort!(
                 meta.span(),
-                "'forward' attribute value can be provided as 'forward = x' or forward = [x, y, z].",
+                "'forward' attribute value must be provided as 'forward = x' or forward = [x, y, z].",
             );
         };
         let mut values = Vec::new();
@@ -956,7 +956,7 @@ impl TryFrom<&syn::Meta> for ForwardAttribute {
                 check!(
                     !expr_array.elems.is_empty(),
                     expr_array.span(),
-                    "'forward' attribute must be non-empty when specified as array of integers"
+                    "'forward' attribute must be non-empty when specified as array of integers."
                 );
                 for elem in &expr_array.elems {
                     match elem {
@@ -986,7 +986,7 @@ impl TryFrom<&syn::Meta> for ForwardAttribute {
             _ => {
                 abort!(
                     name_value.span(),
-                    "'forward' attribute value can be provided as 'forward = x' or forward = [x, \
+                    "'forward' attribute value must be provided as 'forward = x' or forward = [x, \
                      y, z]."
                 );
             }
@@ -1081,7 +1081,7 @@ pub fn impl_deserial(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
             check!(
                 container_attributes.repr.is_none(),
                 ast.span(),
-                "'repr(..)' attribute can only be used on an enum"
+                "'repr(..)' attribute can only be used on an enum."
             );
 
             let return_tokens = match data.fields {
@@ -1183,7 +1183,7 @@ pub fn impl_deserial(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
                         variant.fields.len() == 1,
                         variant.span(),
                         "Only enum variants containing a single field can be used with the \
-                         'forward' attribute"
+                         'forward' attribute."
                     );
                     let chained_source = format_ident!("___chained_source");
 
@@ -1195,14 +1195,14 @@ pub fn impl_deserial(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
 
                     let mut tags = Vec::new();
                     for forward_attribute in variant_attributes.forwards {
-                        for value in forward_attribute.values {
-                            for tag_lit in value.get_literals() {
+                        for forward_value in forward_attribute.values {
+                            for tag_literal in forward_value.get_literals() {
                                 tag_checker.add_and_check(
-                                    tag_lit.clone(),
-                                    tag_lit.span(),
+                                    tag_literal.clone(),
+                                    tag_literal.span(),
                                     variant_ident,
                                 )?;
-                                tags.push(tag_lit);
+                                tags.push(tag_literal);
                             }
                         }
                     }
@@ -1341,7 +1341,7 @@ pub fn impl_serial(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
             check!(
                 container_attributes.repr.is_none(),
                 ast.span(),
-                "'repr(..)' attribute can only be used on an enum",
+                "'repr(..)' attribute can only be used on an enum.",
             );
 
             let fields_tokens = match data.fields {
@@ -1433,7 +1433,7 @@ pub fn impl_serial(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
                         variant.fields.len() == 1,
                         variant.span(),
                         "Only enum variants containing a single field can be used with the \
-                         'forward' attribute"
+                         'forward' attribute."
                     );
 
                     proc_macro2::TokenStream::new()
@@ -1448,11 +1448,11 @@ pub fn impl_serial(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
 
                 tag_checker.add_and_check(tag_lit, tag_span, &variant.ident)?;
                 for forward_attribute in variant_attributes.forwards {
-                    for value in forward_attribute.values {
-                        for tag_lit in value.get_literals() {
+                    for forward_value in forward_attribute.values {
+                        for tag_literal in forward_value.get_literals() {
                             tag_checker.add_and_check(
-                                tag_lit.clone(),
-                                tag_lit.span(),
+                                tag_literal.clone(),
+                                tag_literal.span(),
                                 variant_ident,
                             )?;
                         }
@@ -1566,7 +1566,7 @@ pub fn impl_deserial_with_state(ast: &syn::DeriveInput) -> syn::Result<TokenStre
             check!(
                 container_attributes.repr.is_none(),
                 ast.span(),
-                "'repr(..)' attribute can only be used on an enum",
+                "'repr(..)' attribute can only be used on an enum.",
             );
 
             let return_tokens = match data.fields {
@@ -1685,7 +1685,7 @@ pub fn impl_deserial_with_state(ast: &syn::DeriveInput) -> syn::Result<TokenStre
                         variant.fields.len() == 1,
                         variant.span(),
                         "Only enum variants containing a single field can be used with the \
-                         'forward' attribute"
+                         'forward' attribute."
                     );
                     let chained_source = format_ident!("___chained_source");
 
@@ -1697,14 +1697,14 @@ pub fn impl_deserial_with_state(ast: &syn::DeriveInput) -> syn::Result<TokenStre
 
                     let mut tags = Vec::new();
                     for forward_attribute in variant_attributes.forwards {
-                        for value in forward_attribute.values {
-                            for tag_lit in value.get_literals() {
+                        for forward_value in forward_attribute.values {
+                            for tag_literal in forward_value.get_literals() {
                                 tag_checker.add_and_check(
-                                    tag_lit.clone(),
-                                    tag_lit.span(),
+                                    tag_literal.clone(),
+                                    tag_literal.span(),
                                     variant_ident,
                                 )?;
-                                tags.push(tag_lit);
+                                tags.push(tag_literal);
                             }
                         }
                     }
@@ -2205,13 +2205,13 @@ pub fn schema_type_derive_worker(input: TokenStream) -> syn::Result<TokenStream>
             check!(
                 container_attributes.repr.is_none(),
                 ast.span(),
-                "'repr(..)' attribute can only be used on an enum",
+                "'repr(..)' attribute can only be used on an enum.",
             );
             if container_attributes.transparent {
                 check!(
                     data.fields.len() == 1,
                     ast.span(),
-                    "'transparent' attribute can only be used on a struct with a single field",
+                    "'transparent' attribute can only be used on a struct with a single field.",
                 );
 
                 // Safe to unwrap below since we already checked the length is one.
@@ -2228,7 +2228,7 @@ pub fn schema_type_derive_worker(input: TokenStream) -> syn::Result<TokenStream>
             check!(
                 !container_attributes.transparent,
                 ast.span(),
-                "'transparent' attribute can only be used on a struct",
+                "'transparent' attribute can only be used on a struct.",
             );
             let mut used_variant_names = HashMap::new();
             let mut tag_checker = TagChecker::default();
@@ -2279,15 +2279,15 @@ pub fn schema_type_derive_worker(input: TokenStream) -> syn::Result<TokenStream>
                         variant.fields.len() == 1,
                         variant.span(),
                         "Only enum variants containing a single field can be used with the \
-                         'forward' attribute"
+                         'forward' attribute."
                     );
 
                     for forward_attribute in variant_attributes.forwards {
-                        for value in forward_attribute.values {
-                            for tag_lit in value.get_literals() {
+                        for forward_value in forward_attribute.values {
+                            for tag_literal in forward_value.get_literals() {
                                 tag_checker.add_and_check(
-                                    tag_lit.clone(),
-                                    tag_lit.span(),
+                                    tag_literal.clone(),
+                                    tag_literal.span(),
                                     &variant.ident,
                                 )?;
                             }
@@ -2328,7 +2328,7 @@ pub fn schema_type_derive_worker(input: TokenStream) -> syn::Result<TokenStream>
                                                 vec.into_iter().enumerate().map(|(i, variant)| (i as u8, variant)),
                                             )
                                         },
-                                        _ => panic!("Using 'forward' attribute for deriving SchemaType is only supported, when the inner type is an enum"),
+                                        _ => panic!("Using 'forward' attribute for deriving SchemaType is only supported, when the inner type is an enum."),
                                     };
                                     #variant_map_ident.append(&mut inner_map_option);
                                 })
@@ -2354,7 +2354,7 @@ pub fn schema_type_derive_worker(input: TokenStream) -> syn::Result<TokenStream>
                             abort!(
                                 ast.span(),
                                 "Invariant violated for deriving SchemaType: Forwarding data is \
-                                 unexpected here"
+                                 unexpected here."
                             );
                         }
                     })
@@ -2365,7 +2365,7 @@ pub fn schema_type_derive_worker(input: TokenStream) -> syn::Result<TokenStream>
             }
         }
         _ => {
-            abort!(ast.span(), "Union is not supported");
+            abort!(ast.span(), "Union is not supported.");
         }
     };
 

--- a/concordium-contracts-common-derive/src/derive.rs
+++ b/concordium-contracts-common-derive/src/derive.rs
@@ -745,20 +745,20 @@ impl ForwardAttributeValue {
 #[derive(Debug)]
 enum PredefinedForwardValue {
     /// Events from CIS-2.
-    Cis2Events,
+    Cis2,
     /// Events from CIS-3.
-    Cis3Events,
+    Cis3,
     /// Events from CIS-4.
-    Cis4Events,
+    Cis4,
 }
 
 impl PredefinedForwardValue {
     fn get_literals_str(&self) -> Vec<&'static str> {
         use PredefinedForwardValue::*;
         match self {
-            Cis2Events => vec!["255", "254", "253", "252", "251"],
-            Cis3Events => vec!["250"],
-            Cis4Events => vec!["249", "248", "247", "246", "245", "244"],
+            Cis2 => vec!["255", "254", "253", "252", "251"],
+            Cis3 => vec!["250"],
+            Cis4 => vec!["249", "248", "247", "246", "245", "244"],
         }
     }
 }
@@ -1004,11 +1004,11 @@ impl TryFrom<&syn::ExprPath> for PredefinedForwardSpannedValue {
 
     fn try_from(expr_path: &syn::ExprPath) -> Result<Self, Self::Error> {
         let value = if expr_path.path.is_ident("cis2_events") {
-            PredefinedForwardValue::Cis2Events
+            PredefinedForwardValue::Cis2
         } else if expr_path.path.is_ident("cis3_events") {
-            PredefinedForwardValue::Cis3Events
+            PredefinedForwardValue::Cis3
         } else if expr_path.path.is_ident("cis4_events") {
-            PredefinedForwardValue::Cis4Events
+            PredefinedForwardValue::Cis4
         } else {
             abort!(
                 expr_path.span(),

--- a/concordium-contracts-common-derive/src/derive.rs
+++ b/concordium-contracts-common-derive/src/derive.rs
@@ -1105,7 +1105,7 @@ pub fn impl_deserial(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
                         for tag_lit in forward_attribute.values {
                             tag_checker.add_and_check(
                                 tag_lit.clone(),
-                                forward_attribute.span,
+                                tag_lit.span(),
                                 variant_ident,
                             )?;
                             tags.push(tag_lit);
@@ -1600,7 +1600,7 @@ pub fn impl_deserial_with_state(ast: &syn::DeriveInput) -> syn::Result<TokenStre
                         for tag_lit in forward_attribute.values {
                             tag_checker.add_and_check(
                                 tag_lit.clone(),
-                                forward_attribute.span,
+                                tag_lit.span(),
                                 variant_ident,
                             )?;
                             tags.push(tag_lit);

--- a/concordium-contracts-common-derive/src/lib.rs
+++ b/concordium-contracts-common-derive/src/lib.rs
@@ -268,9 +268,11 @@ pub fn deserial_with_state_derive(input: TokenStream) -> TokenStream {
 /// nested enum. This attribute takes a tag or a list of tags and changes the
 /// (de)serialization to hide the nesting. The `SchemaType` produced is a
 /// flatten enum hiding the nested enum.
-/// Note that the schema can only be build when the nested type is an enum
-/// implementing `SchemaType` and the compiler is unable to catch this sort of
-/// mistakes until attempting to build the schema from a smart contract.
+/// Note that the schema can only be built when the nested type is an enum
+/// implementing `SchemaType`.
+/// Incorrect use will **not** be caught when compiling the contract itself but
+/// it will be caught when attempting to build the schema using
+/// `cargo-concordium`.
 ///
 /// ```ignore
 /// #[derive(SchemaType)]

--- a/concordium-contracts-common-derive/src/lib.rs
+++ b/concordium-contracts-common-derive/src/lib.rs
@@ -129,6 +129,18 @@ pub fn deserial_derive(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
+/// Setting `#[concordium(forward = n)]` on a variant will produce an error if:
+/// - The type does _not_ have a `#[concordium(repr(u*))]` attribute.
+/// - If any of the forwarded tags `n` cannot be represented by the
+///   `#[concordium(repr(u*))]`.
+/// - Any of the forwarded tags `n` overlap with a tag of another variant.
+/// - `n` contains a predefined set and the value of `#[concordium(repr(u*))]`
+///   is incompatible.
+/// - If the variant does _not_ have exactly one field.
+///
+/// Note that the derive macro does _not_ check forwarded tags matches the tags
+/// of the inner type.
+///
 /// #### Example
 ///
 /// Example of enum specifying the tag of the variant `A` to the value `42u8`.
@@ -297,6 +309,18 @@ pub fn deserial_with_state_derive(input: TokenStream) -> TokenStream {
 ///     Cis2(Cis2Event),
 /// }
 /// ```
+///
+/// Setting `#[concordium(forward = n)]` on a variant will produce an error if:
+/// - The type does _not_ have a `#[concordium(repr(u*))]` attribute.
+/// - If any of the forwarded tags `n` cannot be represented by the
+///   `#[concordium(repr(u*))]`.
+/// - Any of the forwarded tags `n` overlap with a tag of another variant.
+/// - `n` contains a predefined set and the value of `#[concordium(repr(u*))]`
+///   is incompatible.
+/// - If the variant does _not_ have exactly one field.
+///
+/// Note that the derive macro does _not_ check forwarded tags matches the tags
+/// of the inner type.
 ///
 /// ## Generic type bounds
 ///

--- a/concordium-contracts-common-derive/src/lib.rs
+++ b/concordium-contracts-common-derive/src/lib.rs
@@ -94,6 +94,41 @@ pub fn deserial_derive(input: TokenStream) -> TokenStream {
 /// <i>Note that `SchemaType` currently only supports using a single byte
 /// `#([concordium(repr(u8))]`) when using `#[concordium(tag = ..)]`.</i>
 ///
+/// ### Nesting enums with a flat serialization using `#[concordium(forward = ...)]`
+///
+/// Often it is desired to have a single type representing a parameter or the
+/// events. A general pattern for enums is to nest them, however deriving
+/// serialization for a nested enum introduces an additional tag for the variant
+/// of the top-level enum. The solution is to use the attribute
+/// `#[concordium(forward = ...)]` on the variant with a nested enum.
+/// This attribute takes a tag or a list of tags which changes the serialization
+/// to skip the variant tag and deserialization to match the variant with these
+/// tags and forward the deserialization to the nested enum.
+///
+/// ```ignore
+/// #[derive(Serial, Deserial)]
+/// #[concordium(repr(u8))]
+/// enum Event {
+///     SomeEvent(MyEvent),
+///     #[concordium(forward = [42, 43, 44, 45])]
+///     OtherEvent(NestedEvent),
+/// }
+/// ```
+///
+/// For convenience the attribute also supports the values `cis2_events`,
+/// `cis3_events` and `cis4_events` which are unfolded to the list of tags used
+/// for events in CIS-2, CIS-3 and CIS-4 respectively.
+///
+/// ```ignore
+/// #[derive(Serial, Deserial)]
+/// #[concordium(repr(u8))]
+/// enum Event {
+///     SomeEvent(MyEvent),
+///     #[concordium(forward = cis2_events)]
+///     Cis2(Cis2Event),
+/// }
+/// ```
+///
 /// #### Example
 ///
 /// Example of enum specifying the tag of the variant `A` to the value `42u8`.
@@ -223,6 +258,43 @@ pub fn deserial_with_state_derive(input: TokenStream) -> TokenStream {
 /// The current version of the contract schema cannot express tags encoded with
 /// more than one byte, meaning only the annotation of `#[concordium(repr(u8))]`
 /// can be used, when deriving the `SchemaType`.
+///
+/// ### Nesting enums with a flat serialization using `#[concordium(forward = ...)]`
+///
+/// Often it is desired to have a single type representing a parameter or the
+/// events. A general pattern for enums is to nest them, however deriving
+/// the schema type for enums with nested enums exposes this. The solution is to
+/// use the attribute `#[concordium(forward = ...)]` on the variant with a
+/// nested enum. This attribute takes a tag or a list of tags and changes the
+/// (de)serialization to hide the nesting. The `SchemaType` produced is a
+/// flatten enum hiding the nested enum.
+/// Note that the schema can only be build when the nested type is an enum
+/// implementing `SchemaType` and the compiler is unable to catch this sort of
+/// mistakes until attempting to build the schema from a smart contract.
+///
+/// ```ignore
+/// #[derive(SchemaType)]
+/// #[concordium(repr(u8))]
+/// enum Event {
+///     SomeEvent(MyEvent),
+///     #[concordium(forward = [42, 43, 44, 45])]
+///     OtherEvent(NestedEvent),
+/// }
+/// ```
+///
+/// For convenience the attribute also supports the values `cis2_events`,
+/// `cis3_events` and `cis4_events` which are unfolded to the list of tags used
+/// for events in CIS-2, CIS-3 and CIS-4 respectively.
+///
+/// ```ignore
+/// #[derive(SchemaType)]
+/// #[concordium(repr(u8))]
+/// enum Event {
+///     SomeEvent(MyEvent),
+///     #[concordium(forward = cis2_events)]
+///     Cis2(Cis2Event),
+/// }
+/// ```
 ///
 /// ## Generic type bounds
 ///

--- a/concordium-contracts-common/src/impls.rs
+++ b/concordium-contracts-common/src/impls.rs
@@ -1251,8 +1251,8 @@ impl<T: AsRef<[u8]>> Read for Cursor<T> {
     }
 }
 
-// Unfortunately this has to be implemented for a mutable borrow version, since
-// the usecase where we need this only have a mutable reference available.
+// This implementation deviates from [`std::io::Chain`](https://doc.rust-lang.org/std/io/struct.Chain.html#impl-Read-for-Chain%3CT,+U%3E)
+// since the usecase where we need this only have a mutable reference available.
 impl<'a, 'b, T: Read, U: Read> Read for Chain<&'a mut T, &'b mut U> {
     fn read(&mut self, buf: &mut [u8]) -> ParseResult<usize> {
         if !self.done_first {

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1597,6 +1597,43 @@ pub struct Cursor<T> {
     pub data:   T,
 }
 
+/// Adapter to chain together two readers.
+///
+/// This struct is generally created by calling [`chain`] on a reader.
+/// Please see the documentation of [`chain`] for more details.
+///
+/// [`chain`]: Read::chain
+#[derive(Debug)]
+pub struct Chain<T, U> {
+    pub(crate) first:      T,
+    pub(crate) second:     U,
+    pub(crate) done_first: bool,
+}
+
+impl<T, U> Chain<T, U> {
+    /// Construct a reader by chaining to readers together.
+    pub fn new(first: T, second: U) -> Self {
+        Self {
+            first,
+            second,
+            done_first: false,
+        }
+    }
+
+    /// Consumes the `Chain`, returning the wrapped readers.
+    pub fn into_inner(self) -> (T, U) { (self.first, self.second) }
+
+    /// Gets references to the underlying readers in this `Chain`.
+    pub fn get_ref(&self) -> (&T, &U) { (&self.first, &self.second) }
+
+    /// Gets mutable references to the underlying readers in this `Chain`.
+    ///
+    /// Care should be taken to avoid modifying the internal I/O state of the
+    /// underlying readers as doing so may corrupt the internal state of this
+    /// `Chain`.
+    pub fn get_mut(&mut self) -> (&mut T, &mut U) { (&mut self.first, &mut self.second) }
+}
+
 #[cfg(feature = "std")]
 impl std::error::Error for NewAttributeValueError {}
 

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1619,19 +1619,6 @@ impl<T, U> Chain<T, U> {
             done_first: false,
         }
     }
-
-    /// Consumes the `Chain`, returning the wrapped readers.
-    pub fn into_inner(self) -> (T, U) { (self.first, self.second) }
-
-    /// Gets references to the underlying readers in this `Chain`.
-    pub fn get_ref(&self) -> (&T, &U) { (&self.first, &self.second) }
-
-    /// Gets mutable references to the underlying readers in this `Chain`.
-    ///
-    /// Care should be taken to avoid modifying the internal I/O state of the
-    /// underlying readers as doing so may corrupt the internal state of this
-    /// `Chain`.
-    pub fn get_mut(&mut self) -> (&mut T, &mut U) { (&mut self.first, &mut self.second) }
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
## Purpose

Related to https://github.com/Concordium/concordium-rust-smart-contracts/issues/307.
Support `forward` attribute in derive macros for `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`.
Should be merged before https://github.com/Concordium/concordium-rust-smart-contracts/pull/314

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
