### PR TITLE
Add signature and key types to concordium-contracts-common

### DIFF
--- a/concordium-contracts-common/CHANGELOG.md
+++ b/concordium-contracts-common/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 
+- Add signature and key types to `concordium-contracts-common`.
 - Add `Display` trait to `VersionedModuleSchema` to display the `VersionedModuleSchema` as a JSON template.
 - Add `Display` trait to `SchemaType` to display the `SchemaType` as a JSON template.
 - Add associated function `from_base64_str` to `VersionedModuleSchema` to easily parse from base64

--- a/concordium-contracts-common/Cargo.toml
+++ b/concordium-contracts-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-contracts-common"
-version = "7.0.0"
+version = "7.1.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2021"
 rust-version = "1.65"

--- a/concordium-contracts-common/src/impls.rs
+++ b/concordium-contracts-common/src/impls.rs
@@ -372,6 +372,48 @@ impl<Kind> NonZeroThresholdU8<Kind> {
     };
 }
 
+impl Serial for PublicKeyEd25519 {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.0.serial(out) }
+}
+
+impl Deserial for PublicKeyEd25519 {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        Ok(PublicKeyEd25519(Deserial::deserial(source)?))
+    }
+}
+
+impl schema::SchemaType for PublicKeyEd25519 {
+    fn get_type() -> crate::schema::Type { schema::Type::ByteArray(32) }
+}
+
+impl Serial for PublicKeyEcdsaSecp256k1 {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.0.serial(out) }
+}
+
+impl Deserial for PublicKeyEcdsaSecp256k1 {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        Ok(PublicKeyEcdsaSecp256k1(Deserial::deserial(source)?))
+    }
+}
+
+impl schema::SchemaType for PublicKeyEcdsaSecp256k1 {
+    fn get_type() -> crate::schema::Type { schema::Type::ByteArray(33) }
+}
+
+impl Serial for SignatureEd25519 {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.0.serial(out) }
+}
+
+impl Deserial for SignatureEd25519 {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        Ok(SignatureEd25519(Deserial::deserial(source)?))
+    }
+}
+
+impl schema::SchemaType for SignatureEd25519 {
+    fn get_type() -> crate::schema::Type { schema::Type::ByteArray(64) }
+}
+
 impl Serial for ExchangeRate {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
         out.write_u64(self.numerator())?;

--- a/concordium-contracts-common/src/impls.rs
+++ b/concordium-contracts-common/src/impls.rs
@@ -372,56 +372,16 @@ impl<Kind> NonZeroThresholdU8<Kind> {
     };
 }
 
-impl Serial for PublicKeyEd25519 {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.0.serial(out) }
-}
-
-impl Deserial for PublicKeyEd25519 {
-    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
-        Ok(PublicKeyEd25519(Deserial::deserial(source)?))
-    }
-}
-
 impl schema::SchemaType for PublicKeyEd25519 {
     fn get_type() -> crate::schema::Type { schema::Type::ByteArray(32) }
-}
-
-impl Serial for PublicKeyEcdsaSecp256k1 {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.0.serial(out) }
-}
-
-impl Deserial for PublicKeyEcdsaSecp256k1 {
-    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
-        Ok(PublicKeyEcdsaSecp256k1(Deserial::deserial(source)?))
-    }
 }
 
 impl schema::SchemaType for PublicKeyEcdsaSecp256k1 {
     fn get_type() -> crate::schema::Type { schema::Type::ByteArray(33) }
 }
 
-impl Serial for SignatureEd25519 {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.0.serial(out) }
-}
-
-impl Deserial for SignatureEd25519 {
-    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
-        Ok(SignatureEd25519(Deserial::deserial(source)?))
-    }
-}
-
 impl schema::SchemaType for SignatureEd25519 {
     fn get_type() -> crate::schema::Type { schema::Type::ByteArray(64) }
-}
-
-impl Serial for SignatureEcdsaSecp256k1 {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.0.serial(out) }
-}
-
-impl Deserial for SignatureEcdsaSecp256k1 {
-    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
-        Ok(SignatureEcdsaSecp256k1(Deserial::deserial(source)?))
-    }
 }
 
 impl schema::SchemaType for SignatureEcdsaSecp256k1 {

--- a/concordium-contracts-common/src/impls.rs
+++ b/concordium-contracts-common/src/impls.rs
@@ -414,6 +414,20 @@ impl schema::SchemaType for SignatureEd25519 {
     fn get_type() -> crate::schema::Type { schema::Type::ByteArray(64) }
 }
 
+impl Serial for SignatureEcdsaSecp256k1 {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> { self.0.serial(out) }
+}
+
+impl Deserial for SignatureEcdsaSecp256k1 {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        Ok(SignatureEcdsaSecp256k1(Deserial::deserial(source)?))
+    }
+}
+
+impl schema::SchemaType for SignatureEcdsaSecp256k1 {
+    fn get_type() -> crate::schema::Type { schema::Type::ByteArray(64) }
+}
+
 impl Serial for ExchangeRate {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
         out.write_u64(self.numerator())?;

--- a/concordium-contracts-common/src/lib.rs
+++ b/concordium-contracts-common/src/lib.rs
@@ -83,15 +83,8 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-/// Re-export.
 #[cfg(feature = "std")]
-pub use std::{string::String, vec::Vec};
-
-/// Re-export.
-pub mod collections {
-    #[cfg(feature = "std")]
-    pub use std::collections::BTreeMap;
-}
+use std::{string::String, vec::Vec};
 
 #[macro_use]
 mod traits;
@@ -107,7 +100,7 @@ mod types;
 #[cfg(feature = "smart-contract")]
 pub use concordium_contracts_common_derive::*;
 #[cfg(not(feature = "smart-contract"))]
-pub use concordium_contracts_common_derive::{Deserial, SchemaType, Serial, Serialize};
+pub use concordium_contracts_common_derive::{Deserial, Serial, Serialize};
 
 pub use impls::*;
 pub use traits::*;

--- a/concordium-contracts-common/src/lib.rs
+++ b/concordium-contracts-common/src/lib.rs
@@ -89,9 +89,8 @@ pub use std::{string::String, vec::Vec};
 
 /// Re-export.
 pub mod collections {
-    pub use collections::BTreeMap;
     #[cfg(feature = "std")]
-    use std::collections;
+    pub use std::collections::BTreeMap;
 }
 
 #[macro_use]

--- a/concordium-contracts-common/src/lib.rs
+++ b/concordium-contracts-common/src/lib.rs
@@ -83,6 +83,8 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
 #[cfg(feature = "std")]
 use std::{string::String, vec::Vec};
 

--- a/concordium-contracts-common/src/lib.rs
+++ b/concordium-contracts-common/src/lib.rs
@@ -82,7 +82,7 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
-
+use std::{string::String, vec::Vec};
 #[macro_use]
 mod traits;
 #[macro_use]
@@ -97,7 +97,7 @@ mod types;
 #[cfg(feature = "smart-contract")]
 pub use concordium_contracts_common_derive::*;
 #[cfg(not(feature = "smart-contract"))]
-pub use concordium_contracts_common_derive::{Deserial, Serial, Serialize};
+pub use concordium_contracts_common_derive::{Deserial, SchemaType, Serial, Serialize};
 
 pub use impls::*;
 pub use traits::*;

--- a/concordium-contracts-common/src/lib.rs
+++ b/concordium-contracts-common/src/lib.rs
@@ -82,7 +82,18 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
-use std::{string::String, vec::Vec};
+
+/// Re-export.
+#[cfg(feature = "std")]
+pub use std::{string::String, vec::Vec};
+
+/// Re-export.
+pub mod collections {
+    pub use collections::BTreeMap;
+    #[cfg(feature = "std")]
+    use std::collections;
+}
+
 #[macro_use]
 mod traits;
 #[macro_use]

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "std")]
 use crate as concordium_std;
 pub use crate::hashes::ModuleReference;
 use crate::{constants, to_bytes, Serial};
@@ -557,6 +558,7 @@ impl quickcheck::Arbitrary for PublicKeyEd25519 {
     }
 }
 
+#[cfg(feature = "std")]
 pub(crate) type KeyIndex = u8;
 
 #[cfg(feature = "std")]
@@ -587,6 +589,7 @@ pub struct AccountPublicKeys {
     pub threshold: AccountThreshold,
 }
 
+#[cfg(feature = "std")]
 pub(crate) type CredentialIndex = u8;
 
 #[cfg(feature = "std")]

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -18,6 +18,7 @@ use quickcheck::Gen;
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 #[cfg(feature = "derive-serde")]
 pub use serde_impl::*;
+#[cfg(all(feature = "std", feature = "concordium-quickcheck"))]
 use std::collections::BTreeMap;
 #[cfg(feature = "std")]
 use std::{cmp, convert, fmt, hash, iter, ops, str};
@@ -558,6 +559,7 @@ impl quickcheck::Arbitrary for PublicKeyEd25519 {
 
 pub(crate) type KeyIndex = u8;
 
+#[cfg(feature = "std")]
 #[derive(crate::Serialize, Debug, crate::SchemaType, PartialEq, Eq)]
 /// A public indexed by the signature scheme. Currently only a
 /// single scheme is supported, `ed25519`.
@@ -565,13 +567,15 @@ pub enum PublicKey {
     Ed25519(PublicKeyEd25519),
 }
 
+#[cfg(feature = "std")]
 #[derive(crate::Serialize, Debug, crate::SchemaType, PartialEq, Eq)]
 pub struct CredentialPublicKeys {
     #[concordium(size_length = 1)]
-    pub keys:      BTreeMap<KeyIndex, PublicKey>,
+    pub keys:      crate::collections::BTreeMap<KeyIndex, PublicKey>,
     pub threshold: SignatureThreshold,
 }
 
+#[cfg(feature = "std")]
 #[derive(crate::Serialize, Debug, crate::SchemaType, PartialEq, Eq)]
 /// Public keys of an account, together with the thresholds.
 /// This type is deliberately made opaque, but it has serialization instances
@@ -579,12 +583,13 @@ pub struct CredentialPublicKeys {
 /// than to pass them to verification functions.
 pub struct AccountPublicKeys {
     #[concordium(size_length = 1)]
-    pub keys:      BTreeMap<crate::CredentialIndex, CredentialPublicKeys>,
+    pub keys:      crate::collections::BTreeMap<crate::CredentialIndex, CredentialPublicKeys>,
     pub threshold: AccountThreshold,
 }
 
 pub(crate) type CredentialIndex = u8;
 
+#[cfg(feature = "std")]
 #[derive(crate::Serialize, Debug, crate::SchemaType)]
 #[non_exhaustive]
 /// A cryptographic signature indexed by the signature scheme. Currently only a
@@ -593,6 +598,7 @@ pub enum Signature {
     Ed25519(SignatureEd25519),
 }
 
+#[cfg(feature = "std")]
 #[derive(crate::Serialize, Debug, crate::SchemaType)]
 #[concordium(transparent)]
 /// Account signatures. This is an analogue of transaction signatures that are
@@ -603,14 +609,15 @@ pub enum Signature {
 /// credential indexes, and the inner map maps key indices to [`Signature`]s.
 pub struct AccountSignatures {
     #[concordium(size_length = 1)]
-    pub sigs: BTreeMap<CredentialIndex, CredentialSignatures>,
+    pub sigs: crate::collections::BTreeMap<CredentialIndex, CredentialSignatures>,
 }
 
+#[cfg(feature = "std")]
 #[derive(crate::Serialize, Debug, crate::SchemaType)]
 #[concordium(transparent)]
 pub struct CredentialSignatures {
     #[concordium(size_length = 1)]
-    pub sigs: BTreeMap<KeyIndex, Signature>,
+    pub sigs: crate::collections::BTreeMap<KeyIndex, Signature>,
 }
 
 /// Timestamp represented as milliseconds since unix epoch.

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1,14 +1,15 @@
 use crate as concordium_std;
 pub use crate::hashes::ModuleReference;
 use crate::{constants, to_bytes, Serial};
+#[cfg(all(not(feature = "std"), feature = "concordium-quickcheck"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::collections::BTreeMap;
 #[cfg(not(feature = "std"))]
 use alloc::{borrow::ToOwned, string::String, string::ToString, vec::Vec};
-#[cfg(all(not(feature = "std"), feature = "concordium-quickcheck"))]
-use alloc::{boxed::Box, collections::BTreeMap};
 #[cfg(feature = "fuzz")]
 use arbitrary::Arbitrary;
 use cmp::Ordering;
-#[cfg(feature = "std")]
 use concordium_contracts_common_derive::SchemaType;
 #[cfg(not(feature = "std"))]
 use core::{cmp, convert, fmt, hash, iter, ops, str};
@@ -591,10 +592,8 @@ impl quickcheck::Arbitrary for PublicKeyEd25519 {
     }
 }
 
-#[cfg(feature = "std")]
 pub(crate) type KeyIndex = u8;
 
-#[cfg(feature = "std")]
 #[derive(crate::Serialize, Debug, SchemaType, PartialEq, Eq)]
 /// A public indexed by the signature scheme. Currently only a
 /// single scheme is supported, `ed25519`.
@@ -602,7 +601,6 @@ pub enum PublicKey {
     Ed25519(PublicKeyEd25519),
 }
 
-#[cfg(feature = "std")]
 #[derive(crate::Serialize, Debug, SchemaType, PartialEq, Eq)]
 pub struct CredentialPublicKeys {
     #[concordium(size_length = 1)]
@@ -610,7 +608,6 @@ pub struct CredentialPublicKeys {
     pub threshold: SignatureThreshold,
 }
 
-#[cfg(feature = "std")]
 #[derive(crate::Serialize, Debug, SchemaType, PartialEq, Eq)]
 /// Public keys of an account, together with the thresholds.
 pub struct AccountPublicKeys {
@@ -619,10 +616,8 @@ pub struct AccountPublicKeys {
     pub threshold: AccountThreshold,
 }
 
-#[cfg(feature = "std")]
 pub(crate) type CredentialIndex = u8;
 
-#[cfg(feature = "std")]
 #[derive(crate::Serialize, Debug, SchemaType)]
 #[non_exhaustive]
 /// A cryptographic signature indexed by the signature scheme. Currently only a
@@ -631,7 +626,6 @@ pub enum Signature {
     Ed25519(SignatureEd25519),
 }
 
-#[cfg(feature = "std")]
 #[derive(crate::Serialize, Debug, SchemaType)]
 #[concordium(transparent)]
 /// Account signatures. This is an analogue of transaction signatures that are
@@ -644,7 +638,6 @@ pub struct AccountSignatures {
     pub sigs: BTreeMap<CredentialIndex, CredentialSignatures>,
 }
 
-#[cfg(feature = "std")]
 #[derive(crate::Serialize, Debug, SchemaType)]
 #[concordium(transparent)]
 pub struct CredentialSignatures {

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -1,3 +1,4 @@
+use crate as concordium_std;
 pub use crate::hashes::ModuleReference;
 use crate::{constants, to_bytes, Serial};
 #[cfg(not(feature = "std"))]
@@ -7,9 +8,9 @@ use alloc::{boxed::Box, collections::BTreeMap};
 #[cfg(feature = "fuzz")]
 use arbitrary::Arbitrary;
 use cmp::Ordering;
-use core::marker::PhantomData;
 #[cfg(not(feature = "std"))]
 use core::{cmp, convert, fmt, hash, iter, ops, str};
+use core::{marker::PhantomData, str::FromStr};
 use hash::Hash;
 #[cfg(feature = "concordium-quickcheck")]
 use quickcheck::Gen;
@@ -17,7 +18,6 @@ use quickcheck::Gen;
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 #[cfg(feature = "derive-serde")]
 pub use serde_impl::*;
-#[cfg(all(feature = "std", feature = "concordium-quickcheck"))]
 use std::collections::BTreeMap;
 #[cfg(feature = "std")]
 use std::{cmp, convert, fmt, hash, iter, ops, str};
@@ -447,6 +447,171 @@ pub struct NonZeroThresholdU8<Kind> {
 /// An error type that indicates that a 0 attempted to be used as a signature
 /// threshold.
 pub struct ZeroSignatureThreshold;
+
+/// Public key for Ed25519. Must be 32 bytes long.
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[repr(transparent)]
+pub struct PublicKeyEd25519(pub [u8; 32]);
+
+impl fmt::Display for PublicKeyEd25519 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in self.0 {
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for PublicKeyEd25519 {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() != 64 {
+            return Err(ParseError {});
+        }
+
+        let mut public_key: [u8; 32] = [0u8; 32];
+        for (i, place) in public_key.iter_mut().enumerate() {
+            *place = u8::from_str_radix(&s[2 * i..2 * i + 2], 16).map_err(|_| ParseError {})?;
+        }
+
+        Ok(PublicKeyEd25519(public_key))
+    }
+}
+
+/// Public key for ECDSA over Secp256k1. Must be 33 bytes long.
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[repr(transparent)]
+pub struct PublicKeyEcdsaSecp256k1(pub [u8; 33]);
+
+impl fmt::Display for PublicKeyEcdsaSecp256k1 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in self.0 {
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for PublicKeyEcdsaSecp256k1 {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() != 66 {
+            return Err(ParseError {});
+        }
+
+        let mut public_key: [u8; 33] = [0u8; 33];
+        for (i, place) in public_key.iter_mut().enumerate() {
+            *place = u8::from_str_radix(&s[2 * i..2 * i + 2], 16).map_err(|_| ParseError {})?;
+        }
+
+        Ok(PublicKeyEcdsaSecp256k1(public_key))
+    }
+}
+
+/// Signature for a Ed25519 message. Must be 64 bytes long.
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[repr(transparent)]
+pub struct SignatureEd25519(pub [u8; 64]);
+
+impl fmt::Display for SignatureEd25519 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in self.0 {
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for SignatureEd25519 {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() != 128 {
+            return Err(ParseError {});
+        }
+
+        let mut signature: [u8; 64] = [0u8; 64];
+        for (i, place) in signature.iter_mut().enumerate() {
+            *place = u8::from_str_radix(&s[2 * i..2 * i + 2], 16).map_err(|_| ParseError {})?;
+        }
+
+        Ok(SignatureEd25519(signature))
+    }
+}
+
+#[cfg(feature = "concordium-quickcheck")]
+/// Arbitrary public keys.
+/// Note that this is a simple generator that might produce an array of bytes
+/// that is not a valid public key.
+impl quickcheck::Arbitrary for PublicKeyEd25519 {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        let lower: u128 = quickcheck::Arbitrary::arbitrary(g);
+        let upper: u128 = quickcheck::Arbitrary::arbitrary(g);
+        let mut out = [0u8; 32];
+        out[..16].copy_from_slice(&lower.to_le_bytes());
+        out[16..].copy_from_slice(&upper.to_le_bytes());
+        PublicKeyEd25519(out)
+    }
+}
+
+pub(crate) type KeyIndex = u8;
+
+#[derive(crate::Serialize, Debug, crate::SchemaType, PartialEq, Eq)]
+/// A public indexed by the signature scheme. Currently only a
+/// single scheme is supported, `ed25519`.
+pub enum PublicKey {
+    Ed25519(PublicKeyEd25519),
+}
+
+#[derive(crate::Serialize, Debug, crate::SchemaType, PartialEq, Eq)]
+pub struct CredentialPublicKeys {
+    #[concordium(size_length = 1)]
+    pub keys:      BTreeMap<KeyIndex, PublicKey>,
+    pub threshold: SignatureThreshold,
+}
+
+#[derive(crate::Serialize, Debug, crate::SchemaType, PartialEq, Eq)]
+/// Public keys of an account, together with the thresholds.
+/// This type is deliberately made opaque, but it has serialization instances
+/// since inside smart contracts there is no need to inspect the values other
+/// than to pass them to verification functions.
+pub struct AccountPublicKeys {
+    #[concordium(size_length = 1)]
+    pub keys:      BTreeMap<crate::CredentialIndex, CredentialPublicKeys>,
+    pub threshold: AccountThreshold,
+}
+
+pub(crate) type CredentialIndex = u8;
+
+#[derive(crate::Serialize, Debug, crate::SchemaType)]
+#[non_exhaustive]
+/// A cryptographic signature indexed by the signature scheme. Currently only a
+/// single scheme is supported, `ed25519`.
+pub enum Signature {
+    Ed25519(SignatureEd25519),
+}
+
+#[derive(crate::Serialize, Debug, crate::SchemaType)]
+#[concordium(transparent)]
+/// Account signatures. This is an analogue of transaction signatures that are
+/// part of transactions that get sent to the chain.
+///
+/// This type is deliberately made opaque, but it has serialization instances.
+/// It should be thought of as a nested map, indexed on the outer layer by
+/// credential indexes, and the inner map maps key indices to [`Signature`]s.
+pub struct AccountSignatures {
+    #[concordium(size_length = 1)]
+    pub sigs: BTreeMap<CredentialIndex, CredentialSignatures>,
+}
+
+#[derive(crate::Serialize, Debug, crate::SchemaType)]
+#[concordium(transparent)]
+pub struct CredentialSignatures {
+    #[concordium(size_length = 1)]
+    pub sigs: BTreeMap<KeyIndex, Signature>,
+}
 
 /// Timestamp represented as milliseconds since unix epoch.
 ///

--- a/concordium-contracts-common/src/types.rs
+++ b/concordium-contracts-common/src/types.rs
@@ -613,9 +613,6 @@ pub struct CredentialPublicKeys {
 #[cfg(feature = "std")]
 #[derive(crate::Serialize, Debug, SchemaType, PartialEq, Eq)]
 /// Public keys of an account, together with the thresholds.
-/// This type is deliberately made opaque, but it has serialization instances
-/// since inside smart contracts there is no need to inspect the values other
-/// than to pass them to verification functions.
 pub struct AccountPublicKeys {
     #[concordium(size_length = 1)]
     pub keys:      BTreeMap<CredentialIndex, CredentialPublicKeys>,
@@ -640,7 +637,6 @@ pub enum Signature {
 /// Account signatures. This is an analogue of transaction signatures that are
 /// part of transactions that get sent to the chain.
 ///
-/// This type is deliberately made opaque, but it has serialization instances.
 /// It should be thought of as a nested map, indexed on the outer layer by
 /// credential indexes, and the inner map maps key indices to [`Signature`]s.
 pub struct AccountSignatures {


### PR DESCRIPTION
## Purpose

Signature and key types are not solely used by smart contracts anymore. It makes sense to move them to `concordium-contracts-common` from `concordium-std` so they are easier accessible and can be imported by e.g. backends to construct input parameters.

## Changes

Add signature and key types to `concordium-contracts-common`

