### PR TITLE
Remove `derive(StateClone)` completely

### DIFF
--- a/concordium-contracts-common-derive/CHANGELOG.md
+++ b/concordium-contracts-common-derive/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Support adding `#[concordium(forward = n)]`, for enum variants, where `n` is either an unsigned integer literal, `cis2_events`, `cis3_events`, `cis4_events` or an array of the same options.
   Setting this attribute on a variant overrides the (de)serialization to flatten with the (de)serialization of the inner field when using derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`.
   Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
+- `derive(StateClone)` removed completely, as `StateClone` trait is removed from `concordium-std`
 
 ## concordium-contracts-common-derive 3.0.0 (2023-06-16)
 

--- a/concordium-contracts-common-derive/src/derive.rs
+++ b/concordium-contracts-common-derive/src/derive.rs
@@ -1858,7 +1858,7 @@ pub fn reject_derive_worker(input: TokenStream) -> syn::Result<TokenStream> {
     match i32::try_from(enum_data.variants.len()) {
         Ok(n) if n <= RESERVED_ERROR_CODES.neg() => (),
         _ => {
-            return Err(syn::Error::new(ast.span(), &too_many_variants));
+            return Err(syn::Error::new(ast.span(), too_many_variants));
         }
     };
 
@@ -2126,112 +2126,6 @@ pub fn impl_deletable(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
             fn delete(self) {
                 use concordium_std::Deletable;
                 #body
-            }
-        }
-    };
-
-    Ok(gen.into())
-}
-
-pub fn impl_state_clone(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
-    let data_name = &ast.ident;
-    let state_parameter = match find_state_parameter_attribute(&ast.attrs)? {
-        Some(state_param) => state_param,
-        None => {
-            abort!(
-                Span::call_site(),
-                "StateClone requires the attribute #[concordium(state_parameter = \"S\")], where \
-                 \"S\" should be the HasStateApi generic parameter.",
-            );
-        }
-    };
-
-    let (impl_generics, ty_generics, where_clauses) = ast.generics.split_for_impl();
-    let where_predicates = where_clauses.map(|c| c.predicates.clone());
-    let body_tokens = match ast.data {
-        syn::Data::Struct(ref data) => {
-            let mut field_names = proc_macro2::TokenStream::new();
-            let mut field_tokens = proc_macro2::TokenStream::new();
-            let return_tokens = match data.fields {
-                syn::Fields::Named(_) => {
-                    for field in data.fields.iter() {
-                        let field_ident = field.ident.clone().unwrap(); // safe since named fields.
-                        field_tokens.extend(quote!(let #field_ident = concordium_std::StateClone::clone_state(&self.#field_ident, cloned_state_api);));
-                        field_names.extend(quote!(#field_ident,));
-                    }
-                    quote!(Self{#field_names})
-                }
-                syn::Fields::Unnamed(_) => {
-                    for i in 0..data.fields.len() {
-                        let field_index = syn::Index::from(i);
-                        let variable_ident = format_ident!("x_{}", i);
-                        field_tokens
-                            .extend(quote!(let #variable_ident = concordium_std::StateClone::clone_state(&self.#field_index, cloned_state_api);));
-                        field_names.extend(quote!(#variable_ident,))
-                    }
-                    quote!(Self(#field_names))
-                }
-                syn::Fields::Unit => quote!(Ok(Self {})),
-            };
-            quote! {
-                #field_tokens
-                #return_tokens
-            }
-        }
-        syn::Data::Enum(ref data) => {
-            let mut matches_tokens = proc_macro2::TokenStream::new();
-            for (_, variant) in data.variants.iter().enumerate() {
-                let mut field_names = proc_macro2::TokenStream::new();
-                let mut field_tokens = proc_macro2::TokenStream::new();
-                let variant_ident = &variant.ident;
-
-                let (return_tokens, pattern) = match variant.fields {
-                    syn::Fields::Named(_) => {
-                        for field in variant.fields.iter() {
-                            let field_ident = field.ident.clone().unwrap(); // safe since named fields.
-                            field_tokens.extend(quote!(let #field_ident = concordium_std::StateClone::clone_state(#field_ident, cloned_state_api);));
-                            field_names.extend(quote!(#field_ident,));
-                        }
-                        let pattern = quote!({#field_names});
-                        (quote!(#data_name::#variant_ident #pattern), pattern)
-                    }
-                    syn::Fields::Unnamed(_) => {
-                        for i in 0..variant.fields.len() {
-                            let field_ident = format_ident!("x_{}", i);
-                            field_tokens.extend(quote!(let #field_ident = concordium_std::StateClone::clone_state(#field_ident, cloned_state_api);));
-                            field_names.extend(quote!(#field_ident,));
-                        }
-                        let pattern = quote!((#field_names));
-                        (quote!(#data_name::#variant_ident #pattern), pattern)
-                    }
-                    syn::Fields::Unit => (
-                        quote!(#data_name::#variant_ident #field_names),
-                        proc_macro2::TokenStream::new(),
-                    ),
-                };
-                let variant_ident = &variant.ident;
-
-                matches_tokens.extend(quote! {
-                    #data_name::#variant_ident #pattern => {
-                        #field_tokens
-                        #return_tokens
-                    },
-                })
-            }
-            quote! {
-                match self {
-                    #matches_tokens
-                }
-            }
-        }
-        _ => unimplemented!("#[derive(StateClone)] is not implemented for union."),
-    };
-
-    let gen = quote! {
-        #[automatically_derived]
-        unsafe impl #impl_generics concordium_std::StateClone<#state_parameter> for #data_name #ty_generics where #state_parameter: concordium_std::HasStateApi, #where_predicates {
-            unsafe fn clone_state(&self, cloned_state_api: &#state_parameter) -> Self {
-                #body_tokens
             }
         }
     };

--- a/concordium-contracts-common-derive/src/lib.rs
+++ b/concordium-contracts-common-derive/src/lib.rs
@@ -467,43 +467,6 @@ pub fn deletable_derive(input: TokenStream) -> TokenStream {
     unwrap_or_report(derive::impl_deletable(&ast))
 }
 
-/// Derive the StateClone trait.
-/// See the documentation of
-/// [`derive(StateClone)`](./derive.StateClone.html) for details and
-/// limitations.
-///
-/// The trait is used in the
-/// [`TestHost`](../concordium_std/test_infrastructure/struct.TestHost.html)
-/// when rolling back the state. If that functionality is needed, then this
-/// trait must be derived for types which have not implement the `Clone` trait.
-/// That is, `StateClone` should be derived for types with a non-trivial state.
-/// Non-trivial state here means when you have a type `MyState` which has one or
-/// more fields comprised of
-/// [`StateBox`](../concordium_std/struct.StateBox.html),
-/// [`StateSet`](../concordium_std/struct.StateSet.html), or
-/// [`StateMap`](../concordium_std/struct.StateMap.html).
-///
-/// Please note that it is
-/// necessary to specify the generic parameter name for the
-/// [`HasStateApi`](../concordium_std/trait.HasStateApi.html) generic parameter.
-/// To do so, use the `#[concordium(state_parameter =
-/// "NameOfGenericParameter")]` attribute on the type you are deriving
-/// `StateClone` for.
-///
-/// # Example
-/// ``` ignore
-/// #[derive(Serial, DeserialWithState, StateClone)]
-/// #[concordium(state_parameter = "S")]
-/// struct MyState<S> {
-///    my_state_map: StateMap<SomeType, SomeOtherType, S>,
-/// }
-/// ```
-#[proc_macro_derive(StateClone, attributes(concordium))]
-pub fn state_clone_derive(input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input);
-    unwrap_or_report(derive::impl_state_clone(&ast))
-}
-
 /// Derive the appropriate export for an annotated init function.
 ///
 /// This macro requires the following items to be present


### PR DESCRIPTION
## Purpose

Complementary to https://github.com/Concordium/concordium-rust-smart-contracts/pull/321, which now removes `StateClone` trait completely

## Changes

* Remove `derive(StateClone)` proc macro, as it's not needed anymore

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
